### PR TITLE
fix: correct checkInvalidCliOptions path

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,7 +9,7 @@ const meow = require("meow");
 const linthtml = require("./index");
 
 const presets = require("./presets").presets;
-const checkInvalidCLIOptions = require("./utils/checkInvalidCLIOptions");
+const checkInvalidCLIOptions = require("./utils/checkInvalidCliOptions");
 const printFileReport = require("./printFileReport");
 
 const explorer = cosmiconfig("linthtml", { stopDir: process.cwd(), packageProp: 'linthtmlConfig'});


### PR DESCRIPTION
cli is currently throwing `Error: Cannot find module './utils/checkInvalidCLIOptions'`