### PR TITLE
Fix #55

### DIFF
--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -38,6 +38,7 @@ Parser.prototype.parse = function(htmlText) {
     this.parser.reset();
   }
   dom = merge_node_indent(dom);
+  dom = update_line_col_if_needed(dom);
   return dom;
 };
 
@@ -68,6 +69,21 @@ function merge_node_indent(dom) {
     if (node.children) {
       node.children = merge_node_indent(node.children);
     }
+    return node;
+  });
+}
+
+function update_line_col_if_needed(dom) {
+  return dom.map((node) => {
+    if (node.type === "text" && is_indent_only(node) === false) {
+      // todo: Remove after dom parser refactor. Text node should not contain '\n' (at the beginning at least)
+      node.lineCol[0] = /^\n/gmi.test(node.data)? node.lineCol[0] + 1: node.lineCol[0];
+    }
+    
+    if (node.children) {
+      node.children = update_line_col_if_needed(node.children);
+    }
+
     return node;
   });
 }

--- a/lib/rules/indent-style/__tests__/fixtures/valid.html
+++ b/lib/rules/indent-style/__tests__/fixtures/valid.html
@@ -14,6 +14,10 @@
       <p>foo</p><p>bar</p>
     </div>
 
+    <p>
+      foo<span>bar</span>
+    </p>
+
     <div>
       <p>foo</p>
       <p>bar</p>


### PR DESCRIPTION
This PR solve the reported in this issue #55

LintHTML was reporting an indent error for this valid HTML

```html
<p>
    foo <span>bar</span>
</p>
```