### PR TITLE
Don't report errors for newline in attributes when attr-no-unsafe is on

### DIFF
--- a/lib/rules/attr-no-unsafe-char/README.md
+++ b/lib/rules/attr-no-unsafe-char/README.md
@@ -1,6 +1,6 @@
 # attr-no-unsafe-char
 
-If set, unsafe characters may not be used in attribute values. The unsafe characters are those whose unicode values lie in the ranges 0000-001f, 007f-009f, 00ad, 0600-0604, 070f, 17b4, 17b5, 200c-200f, 2028-202f, 2060-206f, feff, fff0-ffff.
+If set, unsafe characters may not be used in attribute values. The unsafe characters are those whose unicode values lie in the ranges 0000-0009, 000b-000c, 000e-001f, 007f-009f, 00ad, 0600-0604, 070f, 17b4, 17b5, 200c-200f, 2028-202f, 2060-206f, feff, fff0-ffff.
 
 The following patterns are considered violations:
 

--- a/lib/rules/attr-no-unsafe-char/__tests__/index.js
+++ b/lib/rules/attr-no-unsafe-char/__tests__/index.js
@@ -15,6 +15,18 @@ describe("attr-no-unsafe-char", function() {
     expect(issues).to.have.lengthOf(0);
   });
 
+  it("Should not report error for tabs/new_line in attributes", async function() {
+    const linter = createLinter();
+    const html = `
+      <div class="
+        foo
+        bar">
+      </div>`;
+    
+    const issues = await linter.lint(html, none, { "attr-no-unsafe-char": true });
+    expect(issues).to.have.lengthOf(0);
+  });
+
   it("Should report error for unsafe char in attributes", async function() {
     const linter = createLinter();
     const html = `<div class="\u070f"></div>`;

--- a/lib/rules/attr-no-unsafe-char/index.js
+++ b/lib/rules/attr-no-unsafe-char/index.js
@@ -1,6 +1,6 @@
-var Issue = require("../../issue");
+const Issue = require("../../issue");
 /* eslint-disable-next-line no-control-regex */
-var regUnsafe = /[\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/;
+const regUnsafe = /[\u0000-\u0009\u000b\u000c\u000e-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/;
 
 module.exports = {
   name: "attr-no-unsafe-char",
@@ -8,7 +8,7 @@ module.exports = {
   desc: [
     "If set, unsafe characters may not be used in attribute values.",
     "The unsafe characters are those whose unicode values lie in the ranges",
-    "0000-001f, 007f-009f, 00ad, 0600-0604, 070f,",
+    "0000-0009, 000b-000c, 000e-001f, 007f-009f, 00ad, 0600-0604, 070f,",
     "17b4, 17b5, 200c-200f, 2028-202f, 2060-206f, feff, fff0-ffff."
   ].join("\n")
 };


### PR DESCRIPTION
Solve an issue reported in #55