### PR TITLE
fix: Always returning 0 response-code 

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -13,7 +13,7 @@ const checkInvalidCLIOptions = require("./utils/checkInvalidCliOptions");
 const printFileReport = require("./printFileReport");
 
 const explorer = cosmiconfig("linthtml", { stopDir: process.cwd(), packageProp: 'linthtmlConfig'});
-const EXIT_CODE_ERROR = 2;
+const EXIT_CODE_ERROR = 1;
 
 let globalConfig = null;
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -185,9 +185,9 @@ function printReports(reports) {
   if (reports.length > 0) {
     const errorsCount = reports.reduce((count, report) => count + report.issues.length, 0);
     console.log(chalk`{red ✖ ${errorsCount} ${errorsCount > 1 ? "errors" : "error"}}`);
-  } else {
-    console.log("✨  There's no error, good job 👏");
+    return process.exit(EXIT_CODE_ERROR);
   }
+  console.log("✨  There's no error, good job 👏");
 }
 
 function getFilesFromGlob(globPattern) {


### PR DESCRIPTION
This is related to #61.

The current cli doesn't quit the process with an error when there's lint issues. This behavior make it impossible to use LintHTML in a dev routine (ci, git hooks).

This PR solve this problem :+1: