### PR TITLE
Improve raw-ignore-text behavior

### DIFF
--- a/.todo
+++ b/.todo
@@ -1,5 +1,6 @@
 ## refactor
 
+* `raw-ignore-text` Find a better solution than the current one
 * Get rid of the process function in rules. Config send to rules should be the same as the one defined in the config file
   This funciton should be changed for a validation function that raise errors if config is not valid
 * No rules by default

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -46,33 +46,14 @@ function rawIgnoreRegex(html, opts) {
     ];
   }
 
-  var origLineCol = knife.getLineColFunc(html),
-    l = 1, // Current line in the modified string
+  let l = 1, // Current line in the modified string
     d = 0; // Difference between original and modified line numbers
   var lines = [],
     cols = [];
   var total = html.length;
-  html = html.replace(ignore, function(match) {
-    var offset = arguments[arguments.length - 2],
-      start = origLineCol(offset),
-      end = origLineCol(offset + match.length),
-      linediff = end[0] - start[0],
-      newcol = start[0] - d;
-    if (linediff) {
-      for (; l < newcol; l++) {
-        lines[l] = l + d;
-      }
-      d += linediff;
-    }
-    if (!cols[newcol]) {
-      cols[newcol] = [[1, 0, start[0]]];
-    }
-    var col = cols[newcol],
-      st = start[1] - col[col.length - 1][1];
-    col.push([st, end[1] - st, end[0]]);
-    return "";
+  html = html.replace((new RegExp(ignore, 'gm')), function(match) {
+    return match.replace(/[^\n\t\n\r]/g, "¤");
   });
-
   var recoverLineCol;
   function findInCol(col, i) {
     var lo = 0,

--- a/lib/rules/class-no-dup/index.js
+++ b/lib/rules/class-no-dup/index.js
@@ -8,11 +8,13 @@ module.exports = {
 };
 
 module.exports.lint = function(classes/*, opts*/) {
-  var issues = [];
+  let issues = [];
+  const classes_position = classes.lineCol;
   classes = classes.sort();
+  classes = classes.filter(_ => /^¤+$/.test(_) === false);
   for (var i = 0; i < classes.length - 1; i++) {
     if (classes[i + 1] === classes[i]) {
-      issues.push(new Issue("E041", classes.lineCol, { classes: classes[i] }));
+      issues.push(new Issue("E041", classes_position, { classes: classes[i] }));
     }
   }
   return issues;

--- a/lib/rules/class-style/index.js
+++ b/lib/rules/class-style/index.js
@@ -30,9 +30,9 @@ module.exports = {
 };
 
 module.exports.lint = function(classes, opts) {
+  
   var format = opts[this.name] || opts["id-class-style"],
     ignore_class = classes.ignore_class;
-
   if (format === "none") {
     return [];
   }
@@ -41,7 +41,7 @@ module.exports.lint = function(classes, opts) {
 
   return classes
     .filter(function(c, i) {
-      return !(ignore_class[i] || regex.test(c));
+      return !(ignore_class[i] || /^¤+$/.test(c) || regex.test(c));
     })
     .map(function(c) {
       return new Issue("E011", classes.lineCol, {

--- a/lib/rules/id-no-dup/index.js
+++ b/lib/rules/id-no-dup/index.js
@@ -20,7 +20,9 @@ module.exports.lint = function(element/*, opts*/) {
   }
 
   var id = element.attribs.id;
-
+  if (/^¤+$/.test(id.value)) {
+    return;
+  }
   // if we haven't seen the id before, remember it
   // and pass the element
   if (!this.table.hasOwnProperty(id.value)) {

--- a/test/functional/raw-ignore-regex.js
+++ b/test/functional/raw-ignore-regex.js
@@ -62,7 +62,6 @@ describe("raw-ignore-regex", function() {
       "</p>"
     ].join("\n");
     const issues = await linter.lint(html, base, { "raw-ignore-regex": /{{(.*[\n\r].*)+}}/, "line-end-style": false  });
-    console.log(issues)
     expect(issues).to.have.lengthOf(0);
   });
 });

--- a/test/functional/raw-ignore-regex.js
+++ b/test/functional/raw-ignore-regex.js
@@ -1,5 +1,6 @@
 const linthtml = require("../../lib");
 const none = require('../../lib/presets').presets.none;
+const base = require('../../lib/presets').presets.default;
 const { expect } = require("chai");
 
 function createLinter() {
@@ -29,6 +30,39 @@ describe("raw-ignore-regex", function() {
     const html = `\r{\r\r}\r[[\r\n\t fjq\r\n\r]]\r\r`;
 
     const issues = await linter.lint(html, none, { "raw-ignore-regex": /(\{[^]*?\}|\[\[[^]*?\]\])/  });
+    expect(issues).to.have.lengthOf(0);
+  });
+  
+  it("should not cause any error with text", async function() {
+    const linter = createLinter();
+    const html = [
+      "<p>",
+      "\t{{ .aVariable }}",
+      "</p>"
+    ].join("\n");
+
+    const issues = await linter.lint(html, base, { "raw-ignore-regex": /{{.*}}/, "line-end-style": false  });
+    expect(issues).to.have.lengthOf(0);
+  });
+  
+  it("should not cause any error inside attributes work across line break", async function() {
+    const linter = createLinter();
+    const html = `<p class="a {{ if $bar "bar" . }} c {{else}} b{{ /if }}">foo</p>`;
+    const issues = await linter.lint(html, base, { "raw-ignore-regex": /{{.*}}/, "line-end-style": false  });
+    expect(issues).to.have.lengthOf(0);
+  });
+  
+  it("should not cause any error inside on multiline", async function() {
+    const linter = createLinter();
+    const html = [
+      "<p>",
+      "\t{{ ",
+      "\t .aVariable",
+      "\t }}",
+      "</p>"
+    ].join("\n");
+    const issues = await linter.lint(html, base, { "raw-ignore-regex": /{{(.*[\n\r].*)+}}/, "line-end-style": false  });
+    console.log(issues)
     expect(issues).to.have.lengthOf(0);
   });
 });


### PR DESCRIPTION
Current behaviour of `raw-ignore-text` is to remove the text matching the regex, this coud lead to some issues. For example with this html :

```html
<p>
  {{ foo }}
</p>
```
 and `raw-ignore-text: /{{.*}}/`

With the current behavior the html will be transformed in 

```html
<p>
  
</p>
```

This html will be reported as invalid by LintHTML cause there's an empty line with trailing whitespaces.

With the new behaviour `raw-ignore-text` will replace every characters ,matching the regex, with a constant dummy char (`¤`). That way the html received by the rules will have the "size" as the original one