### PR TITLE
[FEAT] Add the possibility to select files to not lint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,51 @@
+# Configuration
+
+_⚠️ this is only for the new [config format](https://github.com/linthtml/linthtml/releases#new-config-file-format) introduced in the 0.3.0_
+
+LintHTML use [cosmiconfig](https://davidtheclark/cosmiconfig) to find and load your configuration. It will looks for the following possible sources:
+
+- a `linthtml` property in `package.json`
+- a `.linthtmlrc`, `.linthtmlrc.json` or `.linthtmlrc.yml` file
+- a `.linthtmlrc.js` file exporting a JS object
+
+You can use the `--config` option to manually target a config file.
+
+The configuration object has the following properties:
+
+## rules
+
+Rules determine what the linter looks and test. All rules are listed here [rules](./rules.md).
+The `rules` property is an object whose keys are rule names and values are rule configuration. For example:
+
+```json
+{
+  "rules": {
+    "line-end-style": [
+      true,
+      "lf"
+    ]
+  }
+}
+```
+
+Each rule configuration fits one of the following formats:
+
+- `false`, `true`, `"error"`, `"warning"` or `"off"`. `false` and `"off"` turn the rule off. `"warning"` will make the rules report a warning instead of an error.
+- an array with two values (`[activation option, rule configuration]`)
+
+## ignoreFiles
+
+You can provide a glob or array of globs to ignore specific files.
+
+For example, you can ignore all html files in the `foo` folder.
+
+```json
+{
+  "ignoreFiles": ["foo/*.html"]
+}
+```
+
+LintHTML by default ignore the `node_modules` directory and use the content of the `.gitignore` file.
+This is overriden if `ignoreFiles` is hidden.
+
+_Note: If your `ignoreFiles` list is large use the [`.linthtmlignore`](./ignore-code.md#entire-files) file_

--- a/docs/ignore-code.md
+++ b/docs/ignore-code.md
@@ -1,0 +1,23 @@
+# Ignore code
+
+You can ignore :
+
+<!-- - within files -->
+- entire files
+
+<!-- ## Within files -->
+
+## Entire files
+
+You can use a `.linthtmlignore` files to ignore specific files. For example:
+
+```
+dist/*.html
+vendor/*.thml
+```
+
+The patterns in your `.linthtmlignore` file must match [`.gitignore` syntax](https://git-scm.com/docs/gitignore) (The package [`node-ignore`](https://www.npmjs.com/package/ignore) is used to parse the patterns). _The patterns in `.linthtmlignore` are always relative to `process.cwd()`.
+
+LintHTML looks for a `.linthmlignore` file in `process.cwd()`.
+
+_Alternatively, you can add an [`ignoreFiles` property](./configuration.md#ignorefiles) within your configuration object.

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -19,13 +19,6 @@ const EXIT_CODE_NORMAL = 0;
 
 const pkg = require("../../package.json");
 
-const excludedFolders = [
-  "!node_modules/",
-  "!.git/",
-  "!temp/",
-  "!.tmp/"
-];
-
 const cliOptions = {
   help: chalk`
     Usage: linthtml [options] file.html [glob] [dir]
@@ -188,7 +181,6 @@ function getFilesFromGlob(globPattern) {
   // const patterns = excludedFolders.concat(globPattern);
   return globby(globPattern, {
     gitignore: true,
-    ignore: excludedFolders,
     expandDirectories: {
       files: ["**/*.html"],
       extensions: ["html"]

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -21,6 +21,10 @@ const EXIT_CODE_NORMAL = 0;
 
 const pkg = require("../../package.json");
 
+const excludedFolders = [
+  "!node_modules/"
+];
+
 const cliOptions = {
   help: chalk`
     Usage: linthtml [options] file.html [glob] [dir]
@@ -179,10 +183,11 @@ function printReports(reports) {
   return exitProcess();
 }
 
-function getFilesFromGlob(globPattern, customIgnore) {
-  // const patterns = excludedFolders.concat(globPattern);
+function getFilesFromGlob(globPattern, ignorePaths) {
+  const customIgnore = ignorePaths === undefined;
   return globby(globPattern, {
-    gitignore: customIgnore === undefined,
+    gitignore: customIgnore,
+    ignore: customIgnore ? excludedFolders : [],
     expandDirectories: {
       files: ["**/*.html"],
       extensions: ["html"]

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,11 +1,13 @@
 /* eslint-disable no-console */
 const fs = require("fs");
+const path = require("path");
 const globby = require("globby");
 const chalk = require("chalk");
 const ora = require("ora");
 const meow = require("meow");
-const linthtml = require("../index");
+const ignore = require("ignore");
 
+const linthtml = require("../index");
 const { config_from_path, find_local_config } = require("./read-config");
 const printErrors = require("./print-errors");
 const presets = require("../presets").presets;
@@ -137,7 +139,7 @@ async function lint(input, config) {
 
   const searchSpinner = ora("Searching for files").start();
   const lintSpinner = ora("Analysing files").start();
-  let files = await getFilesToLint(input);
+  let files = await getFilesToLint(input, config);
   searchSpinner.succeed(`Found ${files.length} files`);
   files = files.map(getFileContent);
   try {
@@ -177,10 +179,10 @@ function printReports(reports) {
   return exitProcess();
 }
 
-function getFilesFromGlob(globPattern) {
+function getFilesFromGlob(globPattern, customIgnore) {
   // const patterns = excludedFolders.concat(globPattern);
   return globby(globPattern, {
-    gitignore: true,
+    gitignore: customIgnore === undefined,
     expandDirectories: {
       files: ["**/*.html"],
       extensions: ["html"]
@@ -188,15 +190,25 @@ function getFilesFromGlob(globPattern) {
   });
 }
 
-function getFilesToLint(input) {
-  return Promise.all(input.map(getFilesFromGlob))
-    .then(flatten);
+function getFilesToLint(input, config) {
+  const { ignoreFiles } = config;
+  return Promise.all(input.map(pattern => getFilesFromGlob(pattern, ignoreFiles)))
+    .then(flatten)
+    .then(filesPath => filterIgnoredFiles(filesPath, ignoreFiles));
+}
+
+function filterIgnoredFiles(filesPath, customIgnore) {
+  if (customIgnore === undefined) {
+    return filesPath;
+  }
+  const ignorer = ignore().add(customIgnore);
+  return ignorer.filter(filesPath);
 }
 
 function getFileContent(name) {
   return {
     name,
-    content: fs.readFileSync(name).toString("utf8")
+    content: fs.readFileSync(name, "utf8")
   };
 }
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -191,10 +191,21 @@ function getFilesFromGlob(globPattern, customIgnore) {
 }
 
 function getFilesToLint(input, config) {
-  const { ignoreFiles } = config;
+  const ignoreConfig = readLintIgnoreFile();
+  let { ignoreFiles } = config;
+  if (ignoreConfig) {
+    ignoreFiles = ignoreConfig;
+  }
   return Promise.all(input.map(pattern => getFilesFromGlob(pattern, ignoreFiles)))
     .then(flatten)
     .then(filesPath => filterIgnoredFiles(filesPath, ignoreFiles));
+}
+
+function readLintIgnoreFile() {
+  const ignore_file_path = path.join(process.cwd(), ".linthtmlignore");
+  if (fs.existsSync(ignore_file_path)) {
+    return fs.readFileSync(ignore_file_path).toString();
+  }
 }
 
 function filterIgnoredFiles(filesPath, customIgnore) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -87,6 +87,8 @@ function extractAllRules(rules) {
   delete o["attr-name-ignore-regex"];
   delete o["id-class-ignore-regex"];
   delete o["line-max-len-ignore-regex"];
+  /* eslint-disable-next-line dot-notation */
+  delete o["ignoreFiles"];
   return o;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2859,6 +2859,12 @@
             "is-glob": "^4.0.1"
           }
         },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
         "import-fresh": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
@@ -5781,10 +5787,9 @@
       }
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
     },
     "import-fresh": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "cosmiconfig": "6.0.0",
     "globby": "10.0.1",
     "htmlparser2": "3.10.1",
+    "ignore": "^5.1.4",
     "inquirer": "^7.0.4",
     "kebabcase": "1.0.1",
     "lodash.pull": "4.1.0",


### PR DESCRIPTION
By default linthtml  ignore the `node_modules` folder and all files listed in the `.gitignore` file.
Now it's possible to manually define the files/folder to exclude.

## Option `ignoreFiles` in the config file (only with the [new format](https://github.com/linthtml/linthtml/releases/tag/0.3.0#new-config-file-format))

Files to ignore can be provided as a glob or array of globs .
For example, to ignore all files in the `foo` folder:
```
{
  "ignoreFiles": ["/foo"]
}
```
## `.linthtmlignore` file 

The patterns in the `.linthtmlignore` file must match `.gitignore` syntax. (Behind the scenes, [node-ignore](https://github.com/kaelzhang/node-ignore) parses your patterns.) 
Patterns in `.linthtmlignore` are always analyzed relative to process.cwd().
