### PR TITLE
chore: add frame to self-closing tag list

### DIFF
--- a/lib/knife/is_void_element.js
+++ b/lib/knife/is_void_element.js
@@ -4,6 +4,7 @@ const elems = [
   "br",
   "col",
   "embed",
+  "frame",
   "hr",
   "img",
   "input",


### PR DESCRIPTION
The HTML Attr `<frame />` is a self-closing tag and throws an [error](https://github.com/linthtml/linthtml/blob/develop/lib/knife/relative_line_col.js#L17-L23) when linting