### PR TITLE
Support simplified Chinese and traditional Chinese

### DIFF
--- a/lib/knife/lang_tag.js
+++ b/lib/knife/lang_tag.js
@@ -150,7 +150,9 @@ const langCodes = [
   "zu",
   // Chinese scripts
   "zh-Hans",
-  "zh-Hant"
+  "zh-Hant",
+  "zh-cmn-Hans",
+  "zh-cmn-Hant"
 ];
 
 function checkLang(code) {


### PR DESCRIPTION
"zh-cmn-Hans": simplified Chinese
"zh-cmn-Hant": traditional Chinese
"cmn" is language code