### PR TITLE
[FEAT] Print config command no longer use the config option value

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -15,6 +15,7 @@ const EXIT_CODE_NORMAL = 0;
 
 const pkg = require("../../package.json");
 const printErrors = require("./print-errors");
+const { find_local_config } = require("../read-config");
 
 const cliOptions = {
   help: chalk`
@@ -45,7 +46,7 @@ const cliOptions = {
       default: true
     },
     "print-config": {
-      type: "boolean"
+      type: "string"
     },
     init: {
       type: "boolean"
@@ -65,7 +66,6 @@ module.exports = (argv) => {
   cliOptions.argv = argv;
   const cli = meow(cliOptions);
   const invalidOptionsMessage = checkInvalidCLIOptions(cliOptions.flags, cli.flags);
-  const config = null;
   if (invalidOptionsMessage) {
     process.stderr.write(invalidOptionsMessage);
     return exitProcess();
@@ -76,17 +76,21 @@ module.exports = (argv) => {
       .then(exitProcess);
   }
 
-  if (cli.flags.config !== undefined) {
-    if (cli.flags.config === "") {
-      console.log(chalk`A file path must be provided when using the {blue.bold config} option.`);
+  if (cli.flags.printConfig !== undefined) {
+    if (cli.flags.printConfig === "") {
+      console.log(chalk`A file path must be provided when using the {blue.bold print-config} option.`);
       process.exit(EXIT_CODE_ERROR); // eslint-disable-line no-process-exit
     }
+    const config = find_local_config(cli.flags.printConfig);
+    if (config) {
+      process.stdout.write(JSON.stringify(config.config, null, "  "));
+      exitProcess();
+    }
+    console.log("Couldn't file a config file to print");
+    exitProcess(true);
   }
 
   // use config_path if provided or search local config file
-  if (cli.flags.printConfig) {
-    process.stdout.write(JSON.stringify(config, null, "  "));
-  }
 
   if (cli.flags.help || cli.flags.h || argv.length === 0) {
     cli.showHelp();


### PR DESCRIPTION
Now the `--print-config` command requires a file path in args.