### PR TITLE
[FEAT] New rule no-surrounding-whitespace

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -70,6 +70,7 @@ const errors = {
   E061: (/* data */) => "WCAG rule 78: Each button element must contain content.",
   E062: (/* data */) => "WCAG rule 74: The label element should not encapsulate select and textarea elements.",
   E063: (/* data */) => "WCAG rule 73: Each fieldset element should contain a legend element.",
+  E064: (data) => `Unexpected space ${data.is_before ? "before" : "after"} text.`,
 
   INLINE_01: ({ instruction }) => `unrecognized linthtml instruction: \`linthtml-${instruction}\``,
   INLINE_02: ({ rule_name }) => `unrecognized rule name \`${rule_name}\` in linthtml-configure instruction`,

--- a/lib/rules/no-surrounding-whitespace/README.md
+++ b/lib/rules/no-surrounding-whitespace/README.md
@@ -1,0 +1,76 @@
+# no-surrounding-space
+
+Disallow extra spacing just after a tag is opened and just before a tag is closed.
+
+
+## The following patterns are considered violations
+
+```html
+<h1> Lorem ipsum</h1>
+```
+
+```html
+<h1>Lorem ipsum   </h1>
+```
+
+```html
+<h1> Lorem ipsum </h1>
+```
+
+```html
+<p> <strong>Lorem</strong> ipsum</p>
+```
+
+```html
+<p> <!-- comment --><strong>Lorem</strong> ipsum</p>
+```
+
+```html
+<div> </div>
+```
+
+## The following patterns are not considered violations
+
+```html
+<h1>Lorem ipsum</h1>
+```
+
+```html
+<p><strong>Lorem</strong> ipsum</p>
+```
+
+```html
+<p><!-- comment --><strong>Lorem</strong> ipsum</p>
+```
+```html
+<p>Lorem <strong>ipsum</strong></p>
+```
+
+```html
+<div>
+    <p>Lorem ipsum dolor sit amet...</p>
+</div>
+```
+
+```html
+<div>
+    <p>
+        Lorem ipsum dolor sit amet...
+    </p>
+</div>
+```
+
+```html
+<div>
+    <p>
+        <!-- comment -->
+        Lorem ipsum dolor sit amet...
+        <!-- comment -->
+    </p>
+</div>
+```
+
+```html
+<div></div>
+```
+

--- a/lib/rules/no-surrounding-whitespace/__tests__/index.js
+++ b/lib/rules/no-surrounding-whitespace/__tests__/index.js
@@ -1,0 +1,222 @@
+const { expect } = require("chai");
+const linthtml = require("../../../index");
+const none = require("../../../presets").presets.none;
+
+describe("legacy linter | no-surrounding-whitespace", function() {
+  function createLinter(config) {
+    return new linthtml.LegacyLinter(linthtml.rules, none, config);
+  }
+
+  it("Should report an error when there's whitespaces at the start of a text node", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p>  foo</p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+    expect(issues[0].position)
+      .to
+      .deep
+      .equal({
+        start: {
+          line: 1,
+          column: 4
+        },
+        end: {
+          line: 1,
+          column: 6
+        }
+      });
+  });
+
+  it("Should report an error when there's whitespaces at the end of a text node", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p>foo  </p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+    expect(issues[0].position)
+      .to
+      .deep
+      .equal({
+        start: {
+          line: 1,
+          column: 7
+        },
+        end: {
+          line: 1,
+          column: 9
+        }
+      });
+  });
+
+  it("Should not report an error when there's whitespaces before a sibling", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p>foo <strong>bar</strong></p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+
+  it("Should not report an error when there's whitespaces after a sibling", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p><strong>foo</strong>  bar</p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+
+  it("should not report an error for indentation text node", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = `
+    <div>
+      <p>foo</p>
+      bar
+    </div>
+    `;
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+
+  it("should report an error", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p> <strong>Lorem</strong> ipsum</p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+    expect(issues[0].position)
+      .to
+      .deep
+      .equal({
+        start: {
+          line: 1,
+          column: 4
+        },
+        end: {
+          line: 1,
+          column: 5
+        }
+      });
+  });
+
+  it("Should no report an error", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = [
+      "<div>",
+      "  <p>Lorem ipsum</p>",
+      "</div>"
+    ].join("\n");
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+});
+describe("no-surrounding-whitespace", function() {
+  function createLinter(rules) {
+    return linthtml.fromConfig({ rules });
+  }
+
+  it("Should report an error when there's whitespaces at the start of a text node", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p>  foo</p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+    expect(issues[0].position)
+      .to
+      .deep
+      .equal({
+        start: {
+          line: 1,
+          column: 4
+        },
+        end: {
+          line: 1,
+          column: 6
+        }
+      });
+  });
+
+  it("Should report an error when there's whitespaces at the end of a text node", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p>foo  </p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+    expect(issues[0].position)
+      .to
+      .deep
+      .equal({
+        start: {
+          line: 1,
+          column: 7
+        },
+        end: {
+          line: 1,
+          column: 9
+        }
+      });
+  });
+
+  it("Should not report an error when there's whitespaces before a sibling", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p>foo <strong>bar</strong></p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+
+  it("Should not report an error when there's whitespaces after a sibling", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p><strong>foo</strong>  bar</p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+
+  it("should not report an error for indentation text node", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = `
+    <div>
+      <p>foo</p>
+      bar
+    </div>
+    `;
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+
+  it("should report an error", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = "<p> <strong>Lorem</strong> ipsum</p>";
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+    expect(issues[0].position)
+      .to
+      .deep
+      .equal({
+        start: {
+          line: 1,
+          column: 4
+        },
+        end: {
+          line: 1,
+          column: 5
+        }
+      });
+  });
+
+  it("Should no report an error", async function() {
+    const linter = createLinter({ "no-surrounding-whitespace": true });
+    const html = [
+      "<div>",
+      "  <p>Lorem ipsum</p>",
+      "</div>"
+    ].join("\n");
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+});

--- a/lib/rules/no-surrounding-whitespace/index.js
+++ b/lib/rules/no-surrounding-whitespace/index.js
@@ -1,0 +1,130 @@
+const { is_text_node } = require("../../knife/tag_utils");
+const { get_lines } = require("../../knife/text_node_utils");
+
+function get_helpful_line_positions(node) {
+  return {
+    next_sibling_line: node.nextSibling
+      ? node.nextSibling.loc.start.line
+      : -1,
+    previous_sibling_line: node.previousSibling
+      ? node.previousSibling.loc.end.line
+      : -1,
+    node_start_line: node.loc.start.line,
+    node_end_line: node.loc.end.line,
+    parent_close_line: node.parent
+      ? node.parent.loc.end.line
+      : -1,
+    parent_start_line: node.parent
+      ? node.parent.loc.start.line
+      : -1
+  };
+}
+
+function should_report_before_error(node, { text, offset }) {
+  const {
+    previous_sibling_line,
+    node_start_line,
+    parent_start_line
+  } = get_helpful_line_positions(node);
+
+  const current_line = node_start_line + offset;
+  const start_whitespace = /^[\s\uFEFF\xA0]+/.exec(text);
+  return start_whitespace &&
+    ((current_line === parent_start_line &&
+    current_line !== previous_sibling_line) ||
+    (current_line !== parent_start_line &&
+      current_line === previous_sibling_line));
+}
+
+function generate_position_before_error(node, { text, offset }) {
+  const {
+    node_start_line
+  } = get_helpful_line_positions(node);
+
+  const current_line = node_start_line + offset;
+  const start_whitespace = /^[\s\uFEFF\xA0]+/.exec(text);
+  return {
+    start: {
+      line: current_line,
+      column: node.loc.start.column
+    },
+    end: {
+      line: current_line,
+      column: node.loc.start.column + start_whitespace[0].length
+    }
+  };
+}
+
+function should_report_after_error(node, { text, offset }) {
+  const {
+    next_sibling_line,
+    node_start_line,
+    parent_close_line
+  } = get_helpful_line_positions(node);
+
+  const current_line = node_start_line + offset;
+  const end_whitespace = /[\s\uFEFF\xA0]+$/.exec(text);
+  return end_whitespace &&
+    text !== end_whitespace[0] &&
+    current_line === parent_close_line &&
+    current_line !== next_sibling_line;
+}
+
+function generate_position_after_error(node, { text, offset }) {
+  const {
+    node_start_line
+  } = get_helpful_line_positions(node);
+
+  const current_line = node_start_line + offset;
+  const end_whitespace = /[\s\uFEFF\xA0]+$/.exec(text);
+  return {
+    start: {
+      line: current_line,
+      column: node.loc.end.column - end_whitespace[0].length
+    },
+    end: {
+      line: current_line,
+      column: node.loc.end.column
+    }
+  };
+}
+
+module.exports = {
+  on: ["dom"],
+  name: "no-surrounding-whitespace",
+  // validateConfig ??? before, after option?
+
+  lint(node, opts, { report }) {
+    if (!is_text_node(node)) {
+      return;
+    }
+
+    const lines = get_lines(node);
+
+    lines.forEach((line) => {
+      if (should_report_before_error(node, line)) {
+        report({
+          code: "E064",
+          position: generate_position_before_error(node, line),
+          meta: {
+            data: {
+              is_before: true
+            }
+          }
+        });
+      }
+
+      if (should_report_after_error(node, line)) {
+        report({
+          code: "E064",
+          position: generate_position_after_error(node, line),
+          meta: {
+            data: {
+              is_before: false
+            }
+          }
+        });
+      }
+    });
+  }
+};


### PR DESCRIPTION
This PR adds the new rule `no-surrounding-whitespace` proposed in issue #148.
This rule forbids the presence of whitespaces before or after a text node.
Here's a list of valid/invalid snippets.


**VALID** snippets:

```html
<h1>Lorem ipsum</h1>
```

```html
<p><strong>Lorem</strong> ipsum</p>
```

```html
<p><!-- comment --><strong>Lorem</strong> ipsum</p>
```

```html
<div>
    <p>Lorem ipsum dolor sit amet...</p>
</div>
```

```html
<div>
    <p>
        Lorem ipsum dolor sit amet...
    </p>
</div>
```

```html
<div>
    <p>
        <!-- comment -->
        Lorem ipsum dolor sit amet...
        <!-- comment -->
    </p>
</div>
```

```html
<div></div>
```

**INVALID** snippets:

```html
<h1> Lorem ipsum</h1>
```

```html
<h1>Lorem ipsum   </h1>
```

```html
<h1> Lorem ipsum </h1>
```

```html
<p> <strong>Lorem</strong> ipsum</p>
```

```html
<p> <!-- comment --><strong>Lorem</strong> ipsum</p>
```

```html
<div> </div>
```