### PR TITLE
[FEAT] Inline instruction to enable/disable rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm uninstall htmllint htmllint-cli
 ```
 
 Then rename the file `.htmlintrc` to `.linthtmlrc`.
-You might want to remove the rules `indent-delta` and `indent-width-cont` from there in case you where using them, since LintHTML's indent style checker deals with those aspects out of the box.
+You might want to remove the rules `indent-delta` and `indent-width-cont` from there in case you were using them since LintHTML's indent style checker deals with those aspects out of the box.
 
 Finally, install LintHTML:
 
@@ -57,29 +57,41 @@ npm install @linthtml/linthtml --save-dev
 
 ## Rules
 
-Current list of rules and deprecations can be found in [docs/rules.md](docs/rules.md).
+The list of current rules and deprecations can be found in [docs/rules.md](docs/rules.md).
 
 ### Global Configuration
 
-By default, LintHTML will look for a JSON, YAML or JavaScript file named `.linthtmlrc.*` or a `linthtmlConfig` section in `package.json`.
+By default, LintHTML will look for a `JSON`, `YAML`, or `JavaScript` file named `.linthtmlrc.*` or a `linthtmlConfig` section in `package.json`.
 Anyway, you can specify a custom configuration file using the `--config` option when running LintHTML in the command line.
 
 ### Inline Configuration
 
-Sometimes it is necessary to disable certain rules for a specific line, block or HTML file.
+Sometimes it is necessary to disable a rule or tweak the configuration for a specific line, block or HTML file.
 This might be the case, for example, for an inline SVG block of code.
-This can be achieved with inline configurations.
+This can be achieved by using inline configurations.
 
-Inline configurations are HTML comments beginning with the keyword `linthtml-configure`:
+Inline configurations are HTML comments beginning with the keyword `linthtml-XXX`.
 
-```html
-<!-- linthtml-configure [rule]="[value]" -->
-```
+`XXX` can be replaced with the following values, which are called instructions.
+Instructions have different effects:
+
+- `configure` : change a rule configuration for the HTML nodes that follow
+- `enable` : activate a rule which was has deactivated previously
+- `disable` : disable a rule
+
+#### Configure instruction
 
 Multiple rules can be set in a single inline configuration comment.
-Values must be surrounded with double/single quotes if they contain spaces, and must be either a valid value for the rule (encoded in pretty-much-JSON), or the string `$previous` (which is special value that recalls the former value of the rule for your convenience).
+Values must be surrounded with double/single quotes if they contain spaces, and must be either a valid value for the rule (encoded in pretty-much-JSON) or the string `$previous` (which is a special value that recalls the former value of the rule for your convenience).
 
 Some examples:
+
+* change the `tag-bans` rule value
+
+```html
+<!-- linthtml-configure tag-bans="['p','style']" -->
+<!-- linthtml-configure tag-bans=['p','style'] -->
+```
 
 * turn off the `attr-bans` rule
 
@@ -89,6 +101,8 @@ Some examples:
 <!-- linthtml-configure attr-bans="off" -->
 ```
 
+_We recommend using the enable/disable instructions instead 😉_
+
 * turn on the `attr-bans` rule
 
 ```html
@@ -96,24 +110,47 @@ Some examples:
 <!-- linthtml-configure attr-bans=true -->
 ```
 
-_⚠️ you can only turn on rules that have being deactivated by an inline config_
-
-* change the `tag-bans` rule value
-
-```html
-<!-- linthtml-configure tag-bans="['p','style']" -->
-<!-- linthtml-configure tag-bans=['p','style'] -->
-```
+_⚠️ you can only turn on rules that have been deactivated by an inline config_
+_We recommend using the enable/disable instructions instead 😉_
 
 * restore the previous value of the `tag-bans` rule
+_⚠️ works only with the legacy config at the moment_
 
 ```html
 <!-- linthtml-configure tag-bans="$previous" -->
 ```
 
-_⚠️ works only with the legacy config at the moment_
-
 It's worth noting that inline configurations only affect the file they're on, so if they are not explicitly reversed with the `$previous` value, they will just apply until the end of the file.
+
+#### Disable/Enable instructions
+
+The `disable` and `enable` instructions only deactivate and activate rules for a specific part of a document.
+
+Some examples:
+
+* turn off the `attr-bans` rule
+
+```html
+<!-- linthtml-disable attr-bans -->
+```
+
+* turn on the `attr-bans` rule
+
+```html
+<!-- linthtml-enable attr-bans -->
+```
+
+_⚠️ you can only turn on rules that have been deactivated by an inline config_
+
+Multiple rules can be provided to the instructions as long as they are separated by a `,`.
+
+```html
+<!-- linthtml-disable attr-bans,indent-style,id-style -->
+<!-- Spaces can be added to improve readability -->
+<!-- linthtml-disable attr-bans, indent-style, id-style -->
+```
+
+When no rules are provided to the instructions, the instructions will affect all rules available for the document that is analysed.
 
 ## Ecosystem
 
@@ -134,6 +171,3 @@ Contributions are welcome, please make sure to use the proper GitHub tag on your
 * `cli`: anything related to LintHTML's CLI
 * `rule`: anything related to the rules (bugs, improvements, docs, new rules...)
 * `core`: anything related to LintHTML's core (file parsing, plugin system...)
-
-<!-- ## License
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Flinthtml%2Flinthtml.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Flinthtml%2Flinthtml?ref=badge_large) -->

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,6 +17,10 @@ function isValidString(str) {
   return ["error", "warning", "off"].indexOf(str) !== -1;
 }
 
+/**
+ * @param {RuleActivationConfig} config
+ * @returns {("error"|"warning")}
+ */
 function getSeverity(config) {
   switch (typeof config) {
     case "boolean":
@@ -28,6 +32,11 @@ function getSeverity(config) {
   }
 }
 
+/**
+ * @param {RuleActivationConfig} options
+ * @param {String} ruleName
+ * @returns {Boolean}
+ */
 function shouldActiveRule(options, ruleName) {
   switch (typeof options) {
     case "boolean":
@@ -45,6 +54,11 @@ function shouldActiveRule(options, ruleName) {
   }
 }
 
+/**
+ * @param {RuleActivationConfig} config
+ * @param {String} ruleName
+ * @returns {Object}
+ */
 function extractRuleConfig(config, ruleName) {
   if (typeof config !== "object") {
     return null;
@@ -99,12 +113,28 @@ function extractAllRules(rules) {
 }
 
 /**
+ * @typedef {(Boolean|"error"|"warning"|"off"|String[])} RuleActivationConfig
+ */
+
+/**
+ * A rule
+ *
+ * @typedef {object} Rule
+ * @property {string} name - Name of the rule.
+ * @property {function} lint - The rule's lint function
+ * @property {function} [configTransform]
+ * @property {function} [validateConfig]
+ */
+
+/**
  * @class Config
- * @constructor
- * @param {} rules -
- * @param {} config -
  */
 class Config {
+  /**
+   * @constructor
+   * @param {Object} rules -
+   * @param {Object} config -
+   */
   constructor(rules = {}, config = {}) {
     // TODO: Remove after v1. No more nested rules
     this.rules = extractAllRules(rules); // validate rules ? Throw error if no name and no lint function?
@@ -128,14 +158,6 @@ class Config {
       this.setRuleConfig(rule, config.rules);
     });
   }
-
-  /**
-   * A rule
-   *
-   * @typedef {object} Rule
-   * @property {string} name - Name of the rule.
-   * @property {function} lint - The rule's lint function
-   */
 
   /**
    * Get a rule by name.

--- a/lib/inline_config.js
+++ b/lib/inline_config.js
@@ -1,5 +1,5 @@
 const CustomError = require("./utils/custom-errors");
-// inline_config 0.1
+// inline_config 0.2
 //
 // config "false", "off" disable rule
 // Rest is treated as rule config
@@ -8,6 +8,12 @@ function is_string_config(str) {
   return /^("|')/.test(str) && /("|')$/.test(str);
 }
 
+/**
+ * Check whether or not an HTML is a inline config node
+ *
+ * @param {import('./parser/index').Node} node
+ * @returns {Boolean}
+ */
 function is_likely_inline_config(node) {
   if (node.type === "comment") {
     const data = node.data.trim();
@@ -16,9 +22,20 @@ function is_likely_inline_config(node) {
   return false;
 }
 
+/**
+ * Validate that inline config contains a valid inline instruction
+ *
+ * @param {string} text
+ * @throws {CustomError}
+ */
 function check_instruction(text) {
   const instruction = (/^linthtml-(\w+)(?:$|\s)/.exec(text))[1];
-  if (instruction !== "configure") {
+  const instruction_types = [
+    "configure",
+    "enable",
+    "disable"
+  ];
+  if (instruction_types.indexOf(instruction) === -1) {
     throw new CustomError("INLINE_01", { instruction });
   }
 }
@@ -44,6 +61,11 @@ function extract_rule_config(text) {
     });
 }
 
+/**
+ *
+ * @param {string} rule_configuration
+ * @returns {*}
+ */
 function parse_config(rule_configuration) {
   const cleaned_rule_configuration = rule_configuration.replace(/^("|')/, "").replace(/("|')$/, "");
   try {
@@ -57,6 +79,12 @@ function parse_config(rule_configuration) {
   }
 }
 
+/**
+ * @param {String} rule_name
+ * @param {Object} rule_configuration
+ * @param {import('./config')} linter_config
+ * @returns { {config?: Object, disabled?: Boolean} }
+ */
 function generate_inline_instruction(rule_name, rule_configuration, linter_config) {
   let rule;
   try {
@@ -82,10 +110,19 @@ function generate_inline_instruction(rule_name, rule_configuration, linter_confi
   }
 }
 
+/**
+ *
+ * @param {String} text
+ * @param {import('./config')} linter_config
+ * @returns {Object}
+ */
 function get_instruction_meta(text, linter_config) {
-  const instruction_meta = (/^linthtml-configure(?:\s+(.*)|$)/.exec(text))[1];
-  if (instruction_meta !== undefined) {
-    const rules_configurations = extract_rule_config(instruction_meta); // report error if only rule_name and nothing else
+  const [, instruction_type, instruction_meta] = (/^linthtml-(enable|disable|configure)(?:\s+(.*)|$)/.exec(text));
+  if (instruction_type === "configure") {
+    const rules_configurations = instruction_meta
+      ? extract_rule_config(instruction_meta) // report error if only rule_name and nothing else
+      : [];
+
     return rules_configurations.reduce((configurations, { rule_name, rule_configuration }) => {
       // there's an extra pair of "|' for string configuration that need to be removed before using JSON.parse
       const cleaned_rule_configuration = parse_config(rule_configuration);
@@ -93,15 +130,23 @@ function get_instruction_meta(text, linter_config) {
       return configurations;
     }, {});
   }
-  return {};
+
+  const rules = instruction_meta
+    ? instruction_meta.trim().split(/\s*,\s*/)
+    : Object.keys(linter_config.activatedRules); // If no rules provided then enable/disabled all activated rules
+
+  return rules.reduce((configurations, rule_name) => {
+    configurations[rule_name] = generate_inline_instruction(rule_name, instruction_type === "enable", linter_config);
+    return configurations;
+  }, {});
 }
 
 /**
+ * Extract inline config form HTML comment node
  *
- *
- * @param {*} node
- * @param {Config} linter_config
- * @param {*} report
+ * @param {import('./parser/index').Node} node
+ * @param {import('./config')} linter_config
+ * @param {Object} report
  * @returns
  */
 module.exports.extract_inline_config = function extract_inline_config(node, linter_config, report) {

--- a/lib/knife/tag_utils.js
+++ b/lib/knife/tag_utils.js
@@ -117,10 +117,14 @@ function get_classes(class_attribute) {
  * @returns {string} name of the tag
  */
 function node_tag_name(node) {
-  if (node.type === "text") {
-    return "Text Node"; // get text node content but truncate ?
+  switch (node.type) {
+    case "text":
+      return "Text Node"; // get text node content but truncate ?
+    case "comment":
+      return "Comment";
+    default:
+      return node.name;
   }
-  return node.name;
 }
 
 module.exports = {

--- a/lib/legacy/config.js
+++ b/lib/legacy/config.js
@@ -1,19 +1,24 @@
-const { is_boolean } = require("../validate_option");
-const pull = require("lodash.pull");
-
 /**
  * The config object stores all possible rules and options and manages
  * dependencies based on which options are enabled.
  * As it runs, it updates the subscribers array for each rule to indicate
  * the active rules and options depending on it.
- * @constructor
- * @param {Object[]} rules - The rules to use.
- * @param {Object[]} options - The options.
+ *
+ * @module Config
  */
-class Config {
-  constructor(rules) {
-    this.options = {};
+const { is_boolean } = require("../validate_option");
+const pull = require("lodash.pull");
 
+class Config {
+  /**
+   *
+   * @constructor
+   * @param {Object[]} rules - The rules to use.
+   */
+  constructor(rules) {
+    /** @public */
+    this.options = {};
+    /** @public */
     this.rulesMap = {};
     if (rules) {
       rules.forEach(this.addRule.bind(this));
@@ -71,6 +76,17 @@ class Config {
         validateConfig: rule.validateConfig || is_boolean
       });
     }
+  }
+
+  /**
+   * Check if the provided string match an existing option
+   *
+   * @param {string} optionName
+   * @memberof Config
+   * @returns {Boolean}
+   */
+  hasOption(name) {
+    return Boolean(this.options[name]);
   }
 
   /**

--- a/lib/legacy/inline_config.js
+++ b/lib/legacy/inline_config.js
@@ -58,11 +58,13 @@ class InlineConfig {
    */
   applyConfig(config) {
     const previous = {};
-
     config.rules.forEach(rule => {
       const isprev = rule.value === "$previous";
       if (rule.type === "rule") {
-        this.setOption(rule.name, isprev ? this.previous[rule.name] : rule.value, isprev, previous);
+        const rules = rule.name === "ALL"
+          ? Object.keys(this.current)
+          : [rule.name];
+        rules.forEach(name => this.setOption(name, isprev ? this.previous[name] : rule.value, isprev, previous));
         /* istanbul ignore else */
       }
     });
@@ -110,30 +112,44 @@ class InlineConfig {
    * Add it to our array indexConfigs.
    * Return a list of issues encountered.
    *
-   * @param {HTML_Node} newIndex - The index to get opts for.
+   * @param {import('../parser/index').Node} node - Comment node
    * @memberof InlineConfig
    */
   feedComment(node) {
+    const issues = [];
+    let settings = [];
     const line = node.data;
-    const match = line.match(/[\s]*linthtml-configure[\s]+(.*)/);
+    const match = line.match(/[\s]*linthtml-(configure|disable|enable)[\s]+(.*)/);
 
     if (!match) {
       return [];
     }
 
-    const keyvals = parse_HTML_attributes(match[1]);
+    const instruction_type = match[1];
 
-    const settings = [];
-    const issues = [];
-    keyvals.forEach((pair) => {
-      // TODO More precise line/column numbers
-      const r = this.parsePair(
-        pair.name,
-        pair.value,
-        node.loc
-      );
-      (r.code ? issues : settings).push(r);
-    });
+    if (instruction_type === "configure") {
+      const key_values = parse_HTML_attributes(match[2]);
+
+      key_values.forEach((pair) => {
+        // TODO More precise line/column numbers
+        const r = this.parsePair(
+          pair.name,
+          pair.value,
+          node.loc
+        );
+        (r.code ? issues : settings).push(r);
+      });
+    } else {
+      const rules_name = (match[2].trim() || "ALL").split(/\s*,\s*/);
+      settings = rules_name.map((rule_name) => ({
+        type: "rule",
+        name: rule_name,
+        value: instruction_type === "enable"
+          ? "$previous"
+          : false
+      }));
+    }
+
     if (settings.length > 0) {
       this.addConfig({
         start: node.startIndex,

--- a/lib/legacy/inline_config.js
+++ b/lib/legacy/inline_config.js
@@ -14,7 +14,7 @@ class InlineConfig {
   /**
    * Creates an instance of InlineConfig.
    * @constructor
-   * @param {Object} config - an option parser.
+   * @param {import('./config')} config - an option parser.
    * If not given here, it must be set with inlineConfig.reset(basis).
    * @memberof InlineConfig
    */
@@ -22,10 +22,6 @@ class InlineConfig {
     this.config = config;
     this.indexConfigs = [];
     this.previous = {};
-  }
-
-  _isOption(name) {
-    return name in this.config.options;
   }
 
   /**
@@ -117,7 +113,7 @@ class InlineConfig {
    */
   feedComment(node) {
     const issues = [];
-    let settings = [];
+    const settings = [];
     const line = node.data;
     const match = line.match(/[\s]*linthtml-(configure|disable|enable)[\s]+(.*)/);
 
@@ -141,13 +137,30 @@ class InlineConfig {
       });
     } else {
       const rules_name = (match[2].trim() || "ALL").split(/\s*,\s*/);
-      settings = rules_name.map((rule_name) => ({
-        type: "rule",
-        name: rule_name,
-        value: instruction_type === "enable"
-          ? "$previous"
-          : false
-      }));
+
+      rules_name.forEach((rule_name) => {
+        if (rule_name !== "ALL" && !this.config.hasOption(rule_name)) {
+          issues.push(
+            new Issue(
+              "INLINE_02",
+              node.loc,
+              "inline_config",
+              {
+                data: {
+                  rule_name: rule_name
+                }
+              }
+            )
+          );
+        }
+        settings.push({
+          type: "rule",
+          name: rule_name,
+          value: instruction_type === "enable"
+            ? "$previous"
+            : false
+        });
+      });
     }
 
     if (settings.length > 0) {
@@ -180,11 +193,13 @@ class InlineConfig {
       return new Issue(
         "E051",
         pos,
-        "", {
+        "",
+        {
           data: {
             name: name
           }
-        });
+        }
+      );
     }
 
     // Strip quotes and replace single quotes with double quotes
@@ -202,7 +217,7 @@ class InlineConfig {
     if (value === "$previous") {
       parsed = "$previous";
     } else {
-      if (!this._isOption(name)) {
+      if (!this.config.hasOption(name)) {
         return new Issue(
           "INLINE_02",
           pos,

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -19,6 +19,25 @@ function rawIgnoreRegex(html, options) {
   });
 }
 
+function merge_inline_config(base_config, new_config) {
+  const merged_config = Object.keys(new_config)
+    .reduce((merged_config, rule_name) => {
+      if (base_config[rule_name]) {
+        merged_config[rule_name] = {
+          ...base_config[rule_name],
+          ...new_config[rule_name]
+        };
+      } else {
+        merged_config[rule_name] = new_config[rule_name];
+      }
+      return merged_config;
+    }, {});
+  return {
+    ...base_config,
+    ...merged_config
+  };
+}
+
 class Linter {
   constructor(config) {
     this.config = new Config(rules, config);
@@ -82,10 +101,8 @@ class Linter {
           ...parent_inline_config
         };
         node.children.forEach((child) => {
-          inline_config = {
-            ...inline_config,
-            ...extract_inline_config(child, this.config, report)
-          };
+          const extracted_inline_config = extract_inline_config(child, this.config, report);
+          inline_config = merge_inline_config(inline_config, extracted_inline_config);
           issues = issues.concat(getIssues(child, inline_config));
         });
       }
@@ -93,10 +110,8 @@ class Linter {
     };
     let inline_config = {};
     const rules_issues = dom.map(node => {
-      inline_config = {
-        ...inline_config,
-        ...extract_inline_config(node, this.config, report)
-      };
+      const extracted_inline_config = extract_inline_config(node, this.config, report);
+      inline_config = merge_inline_config(inline_config, extracted_inline_config);
       return getIssues(node, inline_config);
     });
     return issues.concat(rules_issues);

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -74,7 +74,7 @@ const errors = {
   E064: (data) => `Unexpected space ${data.is_before ? "before" : "after"} text.`,
 
   INLINE_01: ({ instruction }) => `unrecognized linthtml instruction: \`linthtml-${instruction}\``,
-  INLINE_02: ({ rule_name }) => `unrecognized rule name \`${rule_name}\` in linthtml-configure instruction`,
+  INLINE_02: ({ rule_name }) => `unrecognized rule name \`${rule_name}\` in inline configuration`,
   INLINE_03: ({ rule_configuration }) => `malformed linthtml-configure instruction: \`${rule_configuration}\` is not valid JSON  global`,
   INLINE_04: ({ rule_name, error }) => `linthtml-configure instruction for rule \`${rule_name}\` is not valid. ${error}`
 };

--- a/lib/rules/attr-bans/index.js
+++ b/lib/rules/attr-bans/index.js
@@ -40,6 +40,9 @@ function mutConfig(options) {
   if (typeof options === "string" || isRegExp(options)) {
     options = [options];
   }
+  if (typeof options === "boolean") {
+    options = [];
+  }
   return options;
 }
 

--- a/test/unit/inline_config.js
+++ b/test/unit/inline_config.js
@@ -33,320 +33,408 @@ describe("inline_config extraction", function() {
     extract_inline_config(comment, {}, report);
   });
 
-  it("report an error when configuration target a nonexistent rule ", function(done) {
-    const config = new Config({});
-    function report({ code, position, meta }) {
-      expect(code).to.equal("INLINE_02", "Issue with code `INLINE_02` is reported");
-      expect(position)
-        .to
-        .deep
-        .equal({
-          start: {
-            line: 1,
-            column: 1
-          },
-          end: {
-            line: 1,
-            column: 38
+  describe("Configure instruction", function() {
+    it("report an error when configuration target a nonexistent rule ", function(done) {
+      const config = new Config({});
+      function report({ code, position, meta }) {
+        expect(code).to.equal("INLINE_02", "Issue with code `INLINE_02` is reported");
+        expect(position)
+          .to
+          .deep
+          .equal({
+            start: {
+              line: 1,
+              column: 1
+            },
+            end: {
+              line: 1,
+              column: 38
+            }
+          });
+        expect(meta).to.deep.equal({ data: { rule_name: "foo" } });
+        done();
+      }
+      const comment = parse("<!-- linthtml-configure foo=false -->")[0];
+      extract_inline_config(comment, config, report);
+    });
+
+    it("return an inline config object for valid inline config (string)", function() {
+      function report() {
+        throw new Error("Report function should not be called for valid inline config");
+      }
+      const config = new Config({ fooRule });
+      const comment = parse("<!-- linthtml-configure foo='bar' -->")[0];
+      const inline_config = extract_inline_config(comment, config, report);
+
+      expect(inline_config.foo).to.not.be.undefined;
+      expect(inline_config.foo).to.deep.equal({ config: "bar" }, "String value is extracted inside a config object");
+    });
+
+    it("return an inline config object for valid inline config (number)", function() {
+      function report() {
+        throw new Error("Report function should not be called for valid inline config");
+      }
+      const config = new Config({ fooRule });
+      const comment = parse("<!-- linthtml-configure foo=2 -->")[0];
+      const inline_config = extract_inline_config(comment, config, report);
+
+      expect(inline_config.foo).to.not.be.undefined;
+      expect(inline_config.foo).to.deep.equal({ config: 2 }, "Number value is extracted inside a config object");
+    });
+
+    it("return an inline config object for valid inline config (json object)", function() {
+      function report() {
+        throw new Error("Report function should not be called for valid inline config");
+      }
+      const config = new Config({ fooRule });
+      const comment = parse("<!-- linthtml-configure foo={\"bar\": \"fix\"} -->")[0];
+      const inline_config = extract_inline_config(comment, config, report);
+
+      expect(inline_config.foo).to.not.be.undefined;
+      expect(inline_config.foo).to.deep.equal({ config: { bar: "fix" } }, "JSON object is extracted inside a config object");
+    });
+
+    it("return an inline config object for valid inline config (array)", function() {
+      function report() {
+        throw new Error("Report function should not be called for valid inline config");
+      }
+      const config = new Config({ fooRule });
+      const comment = parse("<!-- linthtml-configure foo=[\"bar\"] -->")[0];
+      const inline_config = extract_inline_config(comment, config, report);
+
+      expect(inline_config.foo).to.not.be.undefined;
+      expect(inline_config.foo).to.deep.equal({ config: ["bar"] }, "JSON object is extracted inside a config object");
+    });
+
+    it("return an inline config object for valid inline config (boolean)", function() {
+      function report() {
+        throw new Error("Report function should not be called for valid inline config");
+      }
+      const config = new Config({ fooRule });
+      const comment = parse("<!-- linthtml-configure foo=true -->")[0];
+      const inline_config = extract_inline_config(comment, config, report);
+
+      expect(inline_config.foo).to.not.be.undefined;
+      expect(inline_config.foo).to.deep.equal({ disabled: false }, "JSON object is extracted inside a config object");
+    });
+
+    it("flag rule as disabled if inline config is false", function() {
+      function report() {
+        throw new Error("Report function should not be called for valid inline config");
+      }
+      const config = new Config({ fooRule });
+      const comment = parse("<!-- linthtml-configure foo=false -->")[0];
+      const inline_config = extract_inline_config(comment, config, report);
+
+      expect(inline_config.foo).to.not.be.undefined;
+      expect(inline_config.foo).to.deep.equal({ disabled: true });
+    });
+
+    it("flag rule as disabled if inline config is 'false' (string)", function() {
+      function report() {
+        throw new Error("Report function should not be called for valid inline config");
+      }
+      const config = new Config({ fooRule });
+      const comment = parse("<!-- linthtml-configure foo='false' -->")[0];
+      const inline_config = extract_inline_config(comment, config, report);
+
+      expect(inline_config.foo).to.not.be.undefined;
+      expect(inline_config.foo).to.deep.equal({ disabled: true });
+    });
+
+    it("flag rule as disabled if inline config is 'off' (string)", function() {
+      function report() {
+        throw new Error("Report function should not be called for valid inline config");
+      }
+      const config = new Config({ fooRule });
+      const comment = parse("<!-- linthtml-configure foo='off' -->")[0];
+      const inline_config = extract_inline_config(comment, config, report);
+
+      expect(inline_config.foo).to.not.be.undefined;
+      expect(inline_config.foo).to.deep.equal({ disabled: true });
+    });
+
+    it("one instruction can contain multiple configs", function() {
+      function report() {
+        throw new Error("Report function should not be called for valid inline config");
+      }
+      const config = new Config({
+        fooRule,
+        bar: {
+          name: "bar",
+          lint() {}
+        }
+      });
+      const comment = parse("<!-- linthtml-configure foo='fix' bar='buz' -->")[0];
+      const inline_config = extract_inline_config(comment, config, report);
+
+      expect(inline_config.foo).to.not.be.undefined;
+      expect(inline_config.bar).to.not.be.undefined;
+      expect(inline_config.foo).to.deep.equal({ config: "fix" });
+      expect(inline_config.bar).to.deep.equal({ config: "buz" });
+    });
+
+    describe("configuration format", function() {
+      it("report an error for invalid string (no quotes)", function(done) {
+        const config = new Config({ fooRule });
+        function report({ code, position, meta }) {
+          expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
+          expect(position)
+            .to
+            .deep
+            .equal({
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 36
+              }
+            });
+          expect(meta).to.deep.equal({ data: { rule_configuration: "bar" } });
+          done();
+        }
+        const comment = parse("<!-- linthtml-configure foo=bar -->")[0];
+        extract_inline_config(comment, config, report);
+      });
+
+      it("report an error for empty config (nothing after =)", function(done) {
+        const config = new Config({ fooRule });
+        function report({ code, position, meta }) {
+          expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
+          expect(position)
+            .to
+            .deep
+            .equal({
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 33
+              }
+            });
+          expect(meta).to.deep.equal({ data: { rule_configuration: "" } });
+          done();
+        }
+        const comment = parse("<!-- linthtml-configure foo= -->")[0];
+        extract_inline_config(comment, config, report);
+      });
+
+      it("report an error for invalid object config", function(done) {
+        const config = new Config({ fooRule });
+        function report({ code, position, meta }) {
+          expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
+          expect(position)
+            .to
+            .deep
+            .equal({
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 40
+              }
+            });
+          expect(meta).to.deep.equal({ data: { rule_configuration: "{bar:x}" } });
+          done();
+        }
+        const comment = parse("<!-- linthtml-configure foo={bar:x} -->")[0];
+        extract_inline_config(comment, config, report);
+      });
+
+      it("report an error for invalid array config", function(done) {
+        const config = new Config({ fooRule });
+        function report({ code, position, meta }) {
+          expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
+          expect(position)
+            .to
+            .deep
+            .equal({
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 38
+              }
+            });
+          expect(meta).to.deep.equal({ data: { rule_configuration: "[bar]" } });
+          done();
+        }
+        const comment = parse("<!-- linthtml-configure foo=[bar] -->")[0];
+        extract_inline_config(comment, config, report);
+      });
+
+      it("report an error for invalid json object (no quotes on keys)", function(done) {
+        const config = new Config({ fooRule });
+        function report({ code, position, meta }) {
+          expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
+          expect(position)
+            .to
+            .deep
+            .equal({
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 43
+              }
+            });
+          expect(meta).to.deep.equal({ data: { rule_configuration: "{bar: 'x'}" } });
+          done();
+        }
+        const comment = parse("<!-- linthtml-configure foo={bar: 'x'} -->")[0];
+        extract_inline_config(comment, config, report);
+      });
+
+      it("report an error for invalid json", function(done) {
+        const config = new Config({ fooRule });
+        function report({ code, position, meta }) {
+          expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
+          expect(position)
+            .to
+            .deep
+            .equal({
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 50
+              }
+            });
+          expect(meta).to.deep.equal({ data: { rule_configuration: "[{'foo': 'bar'}}]" } });
+          done();
+        }
+        const comment = parse("<!-- linthtml-configure foo=[{'foo': 'bar'}}] -->")[0];
+        extract_inline_config(comment, config, report);
+      });
+
+      it("report an error if configuration does not pass rule validation", function(done) {
+        const foo = {
+          name: "foo",
+          lint() {},
+          validateConfig() {
+            throw Error("not valid");
+          }
+        };
+        const config = new Config({ foo });
+        function report({ code, position, meta }) {
+          expect(code).to.equal("INLINE_04", "Issue with code `INLINE_03` is reported");
+          expect(position)
+            .to
+            .deep
+            .equal({
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 38
+              }
+            });
+          expect(meta).to.deep.equal({ data: { rule_name: "foo", error: "not valid" } });
+          done();
+        }
+        const comment = parse("<!-- linthtml-configure foo='bar' -->")[0];
+        extract_inline_config(comment, config, report);
+      });
+    });
+  });
+
+  ["enable", "disable"].forEach((instruction) => {
+    describe(`${instruction} instruction`, function() {
+      it("report an error when configuration target a nonexistent rule ", function(done) {
+        const config = new Config({});
+        const html = `<!-- linthtml-${instruction} foo -->`;
+        function report({ code, position, meta }) {
+          expect(code).to.equal("INLINE_02", "Issue with code `INLINE_02` is reported");
+          expect(position)
+            .to
+            .deep
+            .equal({
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: html.length + 1
+              }
+            });
+          expect(meta).to.deep.equal({ data: { rule_name: "foo" } });
+          done();
+        }
+        const comment = parse(html)[0];
+        extract_inline_config(comment, config, report);
+      });
+
+      it("return an inline config object for a valid inline config", function() {
+        function report() {
+          throw new Error("Report function should not be called for valid inline config");
+        }
+        const config = new Config({ fooRule });
+        const comment = parse(`<!-- linthtml-${instruction} foo -->`)[0];
+        const inline_config = extract_inline_config(comment, config, report);
+
+        expect(inline_config.foo).to.not.be.undefined;
+        expect(inline_config.foo).to.deep.equal({ disabled: (instruction === "disable") });
+      });
+
+      it("return an inline config object per rule provided", function() {
+        function report() {
+          throw new Error("Report function should not be called for valid inline config");
+        }
+        const config = new Config({
+          fooRule,
+          bar: {
+            name: "bar",
+            lint() {}
           }
         });
-      expect(meta).to.deep.equal({ data: { rule_name: "foo" } });
-      done();
-    }
-    const comment = parse("<!-- linthtml-configure foo=false -->")[0];
-    extract_inline_config(comment, config, report);
-  });
+        const comment = parse(`<!-- linthtml-${instruction} foo, bar -->`)[0];
+        const inline_config = extract_inline_config(comment, config, report);
+        expect(inline_config.foo).to.not.be.undefined;
+        expect(inline_config.foo).to.deep.equal({ disabled: (instruction === "disable") });
 
-  it("return an inline config object for valid inline config (string)", function() {
-    function report() {
-      throw new Error("Report function should not be called for valid inline config");
-    }
-    const config = new Config({ fooRule });
-    const comment = parse("<!-- linthtml-configure foo='bar' -->")[0];
-    const inline_config = extract_inline_config(comment, config, report);
+        expect(inline_config.bar).to.not.be.undefined;
+        expect(inline_config.bar).to.deep.equal({ disabled: (instruction === "disable") });
+      });
 
-    expect(inline_config.foo).to.not.be.undefined;
-    expect(inline_config.foo).to.deep.equal({ config: "bar" }, "String value is extracted inside a config object");
-  });
-
-  it("return an inline config object for valid inline config (number)", function() {
-    function report() {
-      throw new Error("Report function should not be called for valid inline config");
-    }
-    const config = new Config({ fooRule });
-    const comment = parse("<!-- linthtml-configure foo=2 -->")[0];
-    const inline_config = extract_inline_config(comment, config, report);
-
-    expect(inline_config.foo).to.not.be.undefined;
-    expect(inline_config.foo).to.deep.equal({ config: 2 }, "Number value is extracted inside a config object");
-  });
-
-  it("return an inline config object for valid inline config (json object)", function() {
-    function report() {
-      throw new Error("Report function should not be called for valid inline config");
-    }
-    const config = new Config({ fooRule });
-    const comment = parse("<!-- linthtml-configure foo={\"bar\": \"fix\"} -->")[0];
-    const inline_config = extract_inline_config(comment, config, report);
-
-    expect(inline_config.foo).to.not.be.undefined;
-    expect(inline_config.foo).to.deep.equal({ config: { bar: "fix" } }, "JSON object is extracted inside a config object");
-  });
-
-  it("return an inline config object for valid inline config (array)", function() {
-    function report() {
-      throw new Error("Report function should not be called for valid inline config");
-    }
-    const config = new Config({ fooRule });
-    const comment = parse("<!-- linthtml-configure foo=[\"bar\"] -->")[0];
-    const inline_config = extract_inline_config(comment, config, report);
-
-    expect(inline_config.foo).to.not.be.undefined;
-    expect(inline_config.foo).to.deep.equal({ config: ["bar"] }, "JSON object is extracted inside a config object");
-  });
-
-  it("return an inline config object for valid inline config (boolean)", function() {
-    function report() {
-      throw new Error("Report function should not be called for valid inline config");
-    }
-    const config = new Config({ fooRule });
-    const comment = parse("<!-- linthtml-configure foo=true -->")[0];
-    const inline_config = extract_inline_config(comment, config, report);
-
-    expect(inline_config.foo).to.not.be.undefined;
-    expect(inline_config.foo).to.deep.equal({ disabled: false }, "JSON object is extracted inside a config object");
-  });
-
-  it("flag rule as disabled if inline config is false", function() {
-    function report() {
-      throw new Error("Report function should not be called for valid inline config");
-    }
-    const config = new Config({ fooRule });
-    const comment = parse("<!-- linthtml-configure foo=false -->")[0];
-    const inline_config = extract_inline_config(comment, config, report);
-
-    expect(inline_config.foo).to.not.be.undefined;
-    expect(inline_config.foo).to.deep.equal({ disabled: true });
-  });
-
-  it("flag rule as disabled if inline config is 'false' (string)", function() {
-    function report() {
-      throw new Error("Report function should not be called for valid inline config");
-    }
-    const config = new Config({ fooRule });
-    const comment = parse("<!-- linthtml-configure foo='false' -->")[0];
-    const inline_config = extract_inline_config(comment, config, report);
-
-    expect(inline_config.foo).to.not.be.undefined;
-    expect(inline_config.foo).to.deep.equal({ disabled: true });
-  });
-
-  it("flag rule as disabled if inline config is 'off' (string)", function() {
-    function report() {
-      throw new Error("Report function should not be called for valid inline config");
-    }
-    const config = new Config({ fooRule });
-    const comment = parse("<!-- linthtml-configure foo='off' -->")[0];
-    const inline_config = extract_inline_config(comment, config, report);
-
-    expect(inline_config.foo).to.not.be.undefined;
-    expect(inline_config.foo).to.deep.equal({ disabled: true });
-  });
-
-  it("one instruction can contain configs", function() {
-    function report() {
-      throw new Error("Report function should not be called for valid inline config");
-    }
-    const config = new Config({
-      fooRule,
-      bar: {
-        name: "bar",
-        lint() {}
-      }
-    });
-    const comment = parse("<!-- linthtml-configure foo='fix' bar='buz' -->")[0];
-    const inline_config = extract_inline_config(comment, config, report);
-
-    expect(inline_config.foo).to.not.be.undefined;
-    expect(inline_config.bar).to.not.be.undefined;
-    expect(inline_config.foo).to.deep.equal({ config: "fix" });
-    expect(inline_config.bar).to.deep.equal({ config: "buz" });
-  });
-
-  describe("configuration format", function() {
-    it("report an error for invalid string (no quotes)", function(done) {
-      const config = new Config({ fooRule });
-      function report({ code, position, meta }) {
-        expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
-        expect(position)
-          .to
-          .deep
-          .equal({
-            start: {
-              line: 1,
-              column: 1
-            },
-            end: {
-              line: 1,
-              column: 36
-            }
-          });
-        expect(meta).to.deep.equal({ data: { rule_configuration: "bar" } });
-        done();
-      }
-      const comment = parse("<!-- linthtml-configure foo=bar -->")[0];
-      extract_inline_config(comment, config, report);
-    });
-
-    it("report an error for empty config (nothing after =)", function(done) {
-      const config = new Config({ fooRule });
-      function report({ code, position, meta }) {
-        expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
-        expect(position)
-          .to
-          .deep
-          .equal({
-            start: {
-              line: 1,
-              column: 1
-            },
-            end: {
-              line: 1,
-              column: 33
-            }
-          });
-        expect(meta).to.deep.equal({ data: { rule_configuration: "" } });
-        done();
-      }
-      const comment = parse("<!-- linthtml-configure foo= -->")[0];
-      extract_inline_config(comment, config, report);
-    });
-
-    it("report an error for invalid object config", function(done) {
-      const config = new Config({ fooRule });
-      function report({ code, position, meta }) {
-        expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
-        expect(position)
-          .to
-          .deep
-          .equal({
-            start: {
-              line: 1,
-              column: 1
-            },
-            end: {
-              line: 1,
-              column: 40
-            }
-          });
-        expect(meta).to.deep.equal({ data: { rule_configuration: "{bar:x}" } });
-        done();
-      }
-      const comment = parse("<!-- linthtml-configure foo={bar:x} -->")[0];
-      extract_inline_config(comment, config, report);
-    });
-
-    it("report an error for invalid array config", function(done) {
-      const config = new Config({ fooRule });
-      function report({ code, position, meta }) {
-        expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
-        expect(position)
-          .to
-          .deep
-          .equal({
-            start: {
-              line: 1,
-              column: 1
-            },
-            end: {
-              line: 1,
-              column: 38
-            }
-          });
-        expect(meta).to.deep.equal({ data: { rule_configuration: "[bar]" } });
-        done();
-      }
-      const comment = parse("<!-- linthtml-configure foo=[bar] -->")[0];
-      extract_inline_config(comment, config, report);
-    });
-
-    it("report an error for invalid json object (no quotes on keys)", function(done) {
-      const config = new Config({ fooRule });
-      function report({ code, position, meta }) {
-        expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
-        expect(position)
-          .to
-          .deep
-          .equal({
-            start: {
-              line: 1,
-              column: 1
-            },
-            end: {
-              line: 1,
-              column: 43
-            }
-          });
-        expect(meta).to.deep.equal({ data: { rule_configuration: "{bar: 'x'}" } });
-        done();
-      }
-      const comment = parse("<!-- linthtml-configure foo={bar: 'x'} -->")[0];
-      extract_inline_config(comment, config, report);
-    });
-
-    it("report an error for invalid json", function(done) {
-      const config = new Config({ fooRule });
-      function report({ code, position, meta }) {
-        expect(code).to.equal("INLINE_03", "Issue with code `INLINE_03` is reported");
-        expect(position)
-          .to
-          .deep
-          .equal({
-            start: {
-              line: 1,
-              column: 1
-            },
-            end: {
-              line: 1,
-              column: 50
-            }
-          });
-        expect(meta).to.deep.equal({ data: { rule_configuration: "[{'foo': 'bar'}}]" } });
-        done();
-      }
-      const comment = parse("<!-- linthtml-configure foo=[{'foo': 'bar'}}] -->")[0];
-      extract_inline_config(comment, config, report);
-    });
-
-    it("report an error if configuration does not pass rule validation", function(done) {
-      const foo = {
-        name: "foo",
-        lint() {},
-        validateConfig() {
-          throw Error("not valid");
+      it("return an inline for each activated rules when no rules are listed after the instruction", function() {
+        function report() {
+          throw new Error("Report function should not be called for valid inline config");
         }
-      };
-      const config = new Config({ foo });
-      function report({ code, position, meta }) {
-        expect(code).to.equal("INLINE_04", "Issue with code `INLINE_03` is reported");
-        expect(position)
-          .to
-          .deep
-          .equal({
-            start: {
-              line: 1,
-              column: 1
-            },
-            end: {
-              line: 1,
-              column: 38
-            }
-          });
-        expect(meta).to.deep.equal({ data: { rule_name: "foo", error: "not valid" } });
-        done();
-      }
-      const comment = parse("<!-- linthtml-configure foo='bar' -->")[0];
-      extract_inline_config(comment, config, report);
+        const config = new Config({
+          fooRule,
+          bar: {
+            name: "bar",
+            lint() {}
+          }
+        }, { // active provided rules
+          rules: {
+            bar: true,
+            foo: true
+          }
+        });
+        const comment = parse(`<!-- linthtml-${instruction} -->`)[0];
+        const inline_config = extract_inline_config(comment, config, report);
+        expect(inline_config.foo).to.not.be.undefined;
+        expect(inline_config.foo).to.deep.equal({ disabled: (instruction === "disable") });
+
+        expect(inline_config.bar).to.not.be.undefined;
+        expect(inline_config.bar).to.deep.equal({ disabled: (instruction === "disable") });
+      });
     });
   });
 });
@@ -395,7 +483,7 @@ describe("inline_config with linter", function() {
     expect(issues).to.have.lengthOf(1, "One error is reported as inline_config as root not is not affected by inline_config");
   });
 
-  it("inline config affect siblings after declaration", async function() {
+  it("(configure instruction) inline config affect siblings after declaration", async function() {
     const linter = linthtml.fromConfig({
       rules: {
         "attr-bans": [true, "align"]
@@ -412,7 +500,24 @@ describe("inline_config with linter", function() {
     expect(issues).to.have.lengthOf(1, "One error is reported as inline_config is declared after first <div>");
   });
 
-  it("inline_config only affect rules that are activated at the linter creatinon", async function() {
+  it("(enable|disable instruction) inline config affect siblings after declaration", async function() {
+    const linter = linthtml.fromConfig({
+      rules: {
+        "attr-bans": [true, "align"]
+      }
+    });
+
+    const html = `
+      <div align><div>
+      <!-- linthtml-disable attr-bans -->
+      <div align></div>
+      <div align></div>
+    `;
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1, "One error is reported as inline_config is declared after first <div>");
+  });
+
+  it("inline_config only affect rules that are activated at the linter creation", async function() {
     const linter = linthtml.fromConfig({
       rules: {}
     });
@@ -425,7 +530,7 @@ describe("inline_config with linter", function() {
     expect(issues).to.have.lengthOf(0, "No errors are reported as attr-bans was not configured when linter was created");
   });
 
-  it("inline_config can deactivate/activate rules", async function() {
+  it("(configure instruction) inline_config can deactivate/activate rules", async function() {
     const linter = linthtml.fromConfig({
       rules: {
         "attr-bans": [true, "align"]
@@ -436,6 +541,41 @@ describe("inline_config with linter", function() {
       <!-- linthtml-configure attr-bans=false -->
       <div align></div>
       <!-- linthtml-configure attr-bans=true -->
+      <div align></div>
+    `;
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+  });
+
+  it("(enable|disable instruction) inline_config can deactivate/activate rules", async function() {
+    const linter = linthtml.fromConfig({
+      rules: {
+        "attr-bans": [true, "align"]
+      }
+    });
+
+    const html = `
+      <!-- linthtml-disable attr-bans -->
+      <div align></div>
+      <!-- linthtml-enable attr-bans -->
+      <div align></div>
+    `;
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+  });
+
+  it("enable|disable instructions only enable/disable rules and restore previous rules config", async function() {
+    const linter = linthtml.fromConfig({
+      rules: {
+        "attr-bans": true
+      }
+    });
+
+    const html = `
+      <!-- linthtml-configure attr-bans="align" -->
+      <!-- linthtml-disable attr-bans -->
+      <div align></div>
+      <!-- linthtml-enable attr-bans -->
       <div align></div>
     `;
     const issues = await linter.lint(html);

--- a/test/unit/legacy_inline-configuration.js
+++ b/test/unit/legacy_inline-configuration.js
@@ -48,146 +48,277 @@ describe("inline-configuration", function() {
     expect(issues).to.have.lengthOf(0);
   });
 
-  it("should not do anything on an empty tag", async function() {
-    const linter = createLinter({});
-    const html = "<!-- linthtml-configure -->";
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(0);
-  });
-
-  it("should change options to turn off rules", async function() {
-    const linter = createLinter({ "line-end-style": "crlf" });
-    const html = [
-      "<!-- linthtml-configure line-end-style=\"false\" -->\r\n",
-      "<body>\r\n",
-      "  <p>\r\n",
-      "    some text\r", // Should normaly report an error
-      "  </p>\r\n",
-      "</body>\r\n"
-    ].join("");
-
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(0);
-  });
-
-  it("should work when used multiple times in a line ", async function() {
-    const linter = createLinter({ "line-end-style": "crlf" });
-    const html = [
-      "<!-- linthtml-configure line-end-style=\"lf\" --><!-- linthtml-configure line-end-style=\"false\" -->\r\n",
-      "<body>\n",
-      "  <p>\r",
-      "    some text\r",
-      "  </p>\r",
-      "</body>\r"
-    ].join("");
-
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(0);
-    // Should report 4 errors with "lf"
-    // Should report 4 errors with "crlf"
-  });
-
-  it("Should revert to previous (previous) config using \"$previous\"", async function() {
-    const linter = createLinter({ "line-end-style": "crlf" });
-    const html = [
-      "<!-- linthtml-configure line-end-style=\"false\" --><!-- linthtml-configure line-end-style=\"$previous\" -->\r\n",
-      "<body>\n",
-      "  <p>\r",
-      "    some text\r",
-      "  </p>\r",
-      "</body>\r"
-    ].join("");
-
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(5);
-  });
-
-  it("quotes for valuese should not be mandatory", async function() {
-    const linter = createLinter({ "line-end-style": "crlf" });
-    const html = [
-      "<!-- linthtml-configure line-end-style=false -->\r\n",
-      "<body>\r\n",
-      "  <p>\r\n",
-      "    some text\r", // Should normaly report an error
-      "  </p>\r\n",
-      "</body>\r\n"
-    ].join("");
-
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(0);
-  });
-
-  it("should work for strings without quotes", async function() {
-    const linter = createLinter({ "line-end-style": "cr" });
-    const html = [
-      "<!-- linthtml-configure line-end-style=crlf -->\r",
-      "<body>\r",
-      "  <p>\r",
-      "    some text\r",
-      "  </p>\r",
-      "</body>\r"
-    ].join("");
-
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(6);
-  });
-
-  // TODO: Should report only one error, parsing error
-  it("Should throw an error on bad config formatting", function() {
-    const linter = createLinter({});
-    const html = "<!-- linthtml-configure id-no-dup-\"false\" -->";
-
-    expect(() => linter.lint(html))
-      .to
-      .throw("Cannot parse inline configuration.");
-  });
-
-  it("should report an error for  nonexistent rule name", async function() {
-    const linter = createLinter({});
-    const html = "<!-- linthtml-configure id-no-no-ad=\"false\"-->";
-
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(1);
-    expect(issues[0].code).to.equal("INLINE_02");
-    expect(issues[0].data.rule_name).to.equal("id-no-no-ad");
-  });
-
-  it("Should report an error on invalid option value", async function() {
-    const linter = createLinter({});
-    const html = "<!-- linthtml-configure id-class-no-ad=\"fal#se\"-->";
-
-    // Should not report an error as it's a valid string
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(1);
-    expect(issues[0].code).to.equal("INLINE_03");
-  });
-
-  it("should output an issue on invalid rule name", async function() {
-    const linter = createLinter({});
-    const html = "<!-- linthtml-configure pre#set=\"none\" -->";
-
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(1);
-    expect(issues[0].code).to.equal("E051");
-  });
-
-  it("should change multiple rules", async function() {
-    const linter = createLinter({
-      "line-end-style": "crlf",
-      "id-no-dup": true,
-      "id-class-no-ad": true
+  describe("linthml-configure instruction", function() {
+    it("should not do anything on an empty tag", async function() {
+      const linter = createLinter({});
+      const html = "<!-- linthtml-configure -->";
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0);
     });
-    const html = [
-      "<!-- linthtml-configure line-end-style=\"false\" id-no-dup=\"false\" id-class-no-ad=\"false\" -->\r\n",
-      "<body id=\"foo\" class=\"ad-banner\">\r",
-      "  <p id=\"foo\">\r",
-      "    some text\r",
-      "  </p>\r",
-      "</body>\r"
-    ].join("");
 
-    const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(0);
-    // Should report 7 errors normaly
+    it("should change options to turn off rules", async function() {
+      const linter = createLinter({ "line-end-style": "crlf" });
+      const html = [
+        "<!-- linthtml-configure line-end-style=\"false\" -->\r\n",
+        "<body>\r\n",
+        "  <p>\r\n",
+        "    some text\r", // Should normaly report an error
+        "  </p>\r\n",
+        "</body>\r\n"
+      ].join("");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0);
+    });
+
+    it("should work when used multiple times in a line ", async function() {
+      const linter = createLinter({ "line-end-style": "crlf" });
+      const html = [
+        "<!-- linthtml-configure line-end-style=\"lf\" --><!-- linthtml-configure line-end-style=\"false\" -->\r\n",
+        "<body>\n",
+        "  <p>\r",
+        "    some text\r",
+        "  </p>\r",
+        "</body>\r"
+      ].join("");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0);
+      // Should report 4 errors with "lf"
+      // Should report 4 errors with "crlf"
+    });
+
+    it("Should revert to previous (previous) config using \"$previous\"", async function() {
+      const linter = createLinter({ "line-end-style": "crlf" });
+      const html = [
+        "<!-- linthtml-configure line-end-style=\"false\" --><!-- linthtml-configure line-end-style=\"$previous\" -->\r\n",
+        "<body>\n",
+        "  <p>\r",
+        "    some text\r",
+        "  </p>\r",
+        "</body>\r"
+      ].join("");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(5);
+    });
+
+    it("quotes for valuese should not be mandatory", async function() {
+      const linter = createLinter({ "line-end-style": "crlf" });
+      const html = [
+        "<!-- linthtml-configure line-end-style=false -->\r\n",
+        "<body>\r\n",
+        "  <p>\r\n",
+        "    some text\r", // Should normaly report an error
+        "  </p>\r\n",
+        "</body>\r\n"
+      ].join("");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0);
+    });
+
+    it("should work for strings without quotes", async function() {
+      const linter = createLinter({ "line-end-style": "cr" });
+      const html = [
+        "<!-- linthtml-configure line-end-style=crlf -->\r",
+        "<body>\r",
+        "  <p>\r",
+        "    some text\r",
+        "  </p>\r",
+        "</body>\r"
+      ].join("");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(6);
+    });
+
+    // TODO: Should report only one error, parsing error
+    it("Should throw an error on bad config formatting", function() {
+      const linter = createLinter({});
+      const html = "<!-- linthtml-configure id-no-dup-\"false\" -->";
+
+      expect(() => linter.lint(html))
+        .to
+        .throw("Cannot parse inline configuration.");
+    });
+
+    it("should report an error for  nonexistent rule name", async function() {
+      const linter = createLinter({});
+      const html = "<!-- linthtml-configure id-no-no-ad=\"false\"-->";
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(1);
+      expect(issues[0].code).to.equal("INLINE_02");
+      expect(issues[0].data.rule_name).to.equal("id-no-no-ad");
+    });
+
+    it("Should report an error on invalid option value", async function() {
+      const linter = createLinter({});
+      const html = "<!-- linthtml-configure id-class-no-ad=\"fal#se\"-->";
+
+      // Should not report an error as it's a valid string
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(1);
+      expect(issues[0].code).to.equal("INLINE_03");
+    });
+
+    it("should output an issue on invalid rule name", async function() {
+      const linter = createLinter({});
+      const html = "<!-- linthtml-configure pre#set=\"none\" -->";
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(1);
+      expect(issues[0].code).to.equal("E051");
+    });
+
+    it("should change multiple rules", async function() {
+      const linter = createLinter({
+        "line-end-style": "crlf",
+        "id-no-dup": true,
+        "id-class-no-ad": true
+      });
+      const html = [
+        "<!-- linthtml-configure line-end-style=\"false\" id-no-dup=\"false\" id-class-no-ad=\"false\" -->\r\n",
+        "<body id=\"foo\" class=\"ad-banner\">\r",
+        "  <p id=\"foo\">\r",
+        "    some text\r",
+        "  </p>\r",
+        "</body>\r"
+      ].join("");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0);
+      // Should report 7 errors normaly
+    });
+  });
+
+  describe("linthml-(disable|enable) instruction", function() {
+    it("instruction turn off rule when provided with the name", async function() {
+      const linter = createLinter({ "line-end-style": "crlf" });
+      const html = [
+        "<!-- linthtml-disable line-end-style -->\r\n",
+        "<body>\r\n",
+        "  <p>\r\n",
+        "    some text\r",
+        "  </p>\r\n",
+        "</body>\r\n"
+      ].join("");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0);
+    });
+
+    it("instruction can turn off multiple rules when names are separated using \",\"", async function() {
+      const linter = createLinter({
+        "indent-style": "tabs",
+        "indent-width": 4
+      });
+      const html = [
+        "<!-- linthtml-disable indent-style,indent-width -->",
+        "<body>",
+        "  <p>",
+        "    some text",
+        "  </p>",
+        "</body>"
+      ].join("\n");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0);
+    });
+
+    it("instruction can turn off multiple rules when names are separated using \",\" (+spaces)", async function() {
+      const linter = createLinter({
+        "indent-style": "tabs",
+        "indent-width": 4
+      });
+      const html = [
+        "<!-- linthtml-disable indent-style , indent-width -->",
+        "<body>",
+        "  <p>",
+        "    some text",
+        "  </p>",
+        "</body>"
+      ].join("\n");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0);
+    });
+
+    it("instruction turn off all rules by default", async function() {
+      const linter = createLinter({
+        "indent-style": "tabs",
+        "indent-width": 4
+      });
+      const html = [
+        "<!-- linthtml-disable -->",
+        "<body>",
+        "  <p>",
+        "    some text",
+        "  </p>",
+        "</body>"
+      ].join("\n");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0);
+    });
+
+    it("rules can be turned on again using the enable instruction", async function() {
+      const linter = createLinter({
+        "indent-style": "tabs",
+        "indent-width": 4
+      });
+      const html = [
+        "<!-- linthtml-disable -->",
+        "<!-- linthtml-enable -->",
+        "<body>",
+        "  <p>",
+        "    some text",
+        "  </p>",
+        "</body>"
+      ].join("\n");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(2);
+    });
+
+    it("only one rules can be turned on again", async function() {
+      const linter = createLinter({
+        "indent-style": "tabs",
+        "indent-width": 4
+      });
+      const html = [
+        "<!-- linthtml-disable -->",
+        "<!-- linthtml-enable indent-width -->",
+        "<body>",
+        "  <p>",
+        "    some text",
+        "  </p>",
+        "</body>"
+      ].join("\n");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(1);
+    });
+
+    it("enable instruction restore previous configuration", async function() {
+      const linter = createLinter({
+        "indent-style": "tabs",
+        "indent-width": 4
+      });
+      const html = [
+        "<!-- linthtml-disable -->",
+        "<!-- linthtml-configure indent-width=2 -->",
+        "<!-- linthtml-enable indent-width -->",
+        "<body>",
+        "  <p>",
+        "    some text",
+        "  </p>",
+        "</body>"
+      ].join("\n");
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(0); // no error as configuration instruction as change rule configuration on line 3
+    });
   });
 });

--- a/test/unit/legacy_inline-configuration.js
+++ b/test/unit/legacy_inline-configuration.js
@@ -103,7 +103,7 @@ describe("inline-configuration", function() {
       expect(issues).to.have.lengthOf(5);
     });
 
-    it("quotes for valuese should not be mandatory", async function() {
+    it("quotes for values should not be mandatory", async function() {
       const linter = createLinter({ "line-end-style": "crlf" });
       const html = [
         "<!-- linthtml-configure line-end-style=false -->\r\n",
@@ -299,6 +299,26 @@ describe("inline-configuration", function() {
 
       const issues = await linter.lint(html);
       expect(issues).to.have.lengthOf(1);
+    });
+
+    it("disable instructions report an error for nonexistent rule name", async function() {
+      const linter = createLinter({});
+      const html = "<!-- linthtml-disable id-no-no-ad-->";
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(1);
+      expect(issues[0].code).to.equal("INLINE_02");
+      expect(issues[0].data.rule_name).to.equal("id-no-no-ad");
+    });
+
+    it("enable instructions in report an error for nonexistent rule name", async function() {
+      const linter = createLinter({});
+      const html = "<!-- linthtml-disable id-no-no-ad-->";
+
+      const issues = await linter.lint(html);
+      expect(issues).to.have.lengthOf(1);
+      expect(issues[0].code).to.equal("INLINE_02");
+      expect(issues[0].data.rule_name).to.equal("id-no-no-ad");
     });
 
     it("enable instruction restore previous configuration", async function() {


### PR DESCRIPTION
Add two new inline instructions `enable` and `disable` that can be used to deactivate/activate rules for a specific part of a document.

```html
<!-- linthtml-disable foo -->
<!-- rule foo is disable -->
<div>
  <!-- rule foo is disable -->
   ...
</div>
<!-- linthtml-enable foo -->
<!-- rule foo is no longer disable-->
```