### PR TITLE
[FIX] Correctly report errors for rule `attr-new-line`

### DIFF
--- a/lib/rules/attr-new-line/README.md
+++ b/lib/rules/attr-new-line/README.md
@@ -1,16 +1,18 @@
 # attr-new-line
 
 If set, no more than this number of attributes may be on the same row.
-A value of `0` applies only to the first row, restricting subsequent rows to one element. A value of "+0" is the same but allows an attribute to be on the first row if there is only one attribute.
+A value of `0` applies only to the first row, restricting subsequent rows to one element. A value of `+0` is the same but allows one attribute to be on the first row.
 
-# Options
+## Options
 
 A non-negative integer, or "+0".
 
 Given:
 
-```
+```json
+{
   "attr-new-line": "1"
+}
 ```
 
 The following patterns are considered violations:
@@ -19,10 +21,53 @@ The following patterns are considered violations:
   <button class="foo" id="bar"></button>
 ```
 
-
 The following patterns are not considered violations:
 
 ```html
   <button class="foo"
           id="bar"></button>
+```
+
+Given:
+
+```json
+{
+  "attr-new-line": "0"
+}
+```
+
+The following patterns are considered violations:
+
+```html
+  <button class="foo"></button>
+```
+
+The following patterns are not considered violations:
+
+```html
+  <button
+    id="bar">
+  </button>
+```
+
+Given:
+
+```json
+{
+  "attr-new-line": "+0"
+}
+```
+
+The following patterns are considered violations:
+
+```html
+  <button class="foo" id="bar"></button>
+```
+
+The following patterns are not considered violations:
+
+```html
+  <button class="foo"
+    id="bar">
+  </button>
 ```

--- a/lib/rules/attr-new-line/__tests__/index.js
+++ b/lib/rules/attr-new-line/__tests__/index.js
@@ -56,6 +56,29 @@ describe("legacy linter | attr-new-line", function() {
     expect(issues).to.have.lengthOf(1);
   });
 
+  it("Should not report an error when there's one attribute per line and configuration is '0'", async function() {
+    const linter = createLinter({ "attr-new-line": 0 });
+    const html = `
+      <div 
+          id="bar"
+          attr>
+      </div>
+    `;
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+
+  it("Should report errors when there's more than one attributes per line and configuration is '0'", async function() {
+    const linter = createLinter({ "attr-new-line": 0 });
+    const html = `
+      <div 
+          id="bar" attr>
+      </div>
+    `;
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+  });
+
   it("Should not report an error when there's one attribute on the first line and configuration is '+0'", async function() {
     const linter = createLinter({ "attr-new-line": "+0" });
     const html = "<div class=\"foo\"></div>";
@@ -70,7 +93,7 @@ describe("legacy linter | attr-new-line", function() {
     expect(issues).to.have.lengthOf(1);
   });
 
-  it("Should report an error when there's attributes on line > 1 and configuration is '+0'", async function() {
+  it("Should not report errors when there's one attributes per line and configuration is '+0'", async function() {
     const linter = createLinter({ "attr-new-line": "+0" });
     const html = `
       <div
@@ -79,7 +102,7 @@ describe("legacy linter | attr-new-line", function() {
       </div>
     `;
     const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(2);
+    expect(issues).to.have.lengthOf(0);
   });
 
   it("Should throw an error when an invalid config is provided", function() {
@@ -172,6 +195,39 @@ describe("attr-new-line", function() {
     expect(issues).to.have.lengthOf(1);
   });
 
+  it("Should not report an error when there's one attribute per line and configuration is '0'", async function() {
+    const linter = createLinter({
+      "attr-new-line": [
+        true,
+        0
+      ]
+    });
+    const html = `
+      <div 
+          id="bar"
+          attr>
+      </div>
+    `;
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(0);
+  });
+
+  it("Should report errors when there's more than one attributes per line and configuration is '0'", async function() {
+    const linter = createLinter({
+      "attr-new-line": [
+        true,
+        0
+      ]
+    });
+    const html = `
+      <div 
+          id="bar" attr>
+      </div>
+    `;
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+  });
+
   it("Should not report an error when there's one attribute on the first line and configuration is '+0'", async function() {
     const linter = createLinter({
       "attr-new-line": [
@@ -196,7 +252,7 @@ describe("attr-new-line", function() {
     expect(issues).to.have.lengthOf(1);
   });
 
-  it("Should report an error when there's attributes on line > 1 and configuration is '+0'", async function() {
+  it("Should not report errors when there's one attributes per line and configuration is '+0'", async function() {
     const linter = createLinter({
       "attr-new-line": [
         true,
@@ -210,7 +266,7 @@ describe("attr-new-line", function() {
       </div>
     `;
     const issues = await linter.lint(html);
-    expect(issues).to.have.lengthOf(2);
+    expect(issues).to.have.lengthOf(0);
   });
 
   it("Should throw an error when an invalid config is provided", function() {

--- a/lib/rules/attr-new-line/__tests__/index.js
+++ b/lib/rules/attr-new-line/__tests__/index.js
@@ -93,6 +93,17 @@ describe("legacy linter | attr-new-line", function() {
     expect(issues).to.have.lengthOf(1);
   });
 
+  it("Should report an error when there's more than one attribute on the second line and configuration is '+0'", async function() {
+    const linter = createLinter({ "attr-new-line": "+0" });
+    const html = `
+      <div 
+          id="bar" attr>
+      </div>
+    `;
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
+  });
+
   it("Should not report errors when there's one attributes per line and configuration is '+0'", async function() {
     const linter = createLinter({ "attr-new-line": "+0" });
     const html = `
@@ -267,6 +278,22 @@ describe("attr-new-line", function() {
     `;
     const issues = await linter.lint(html);
     expect(issues).to.have.lengthOf(0);
+  });
+
+  it("Should report an error when there's more than one attribute on the second line and configuration is '+0'", async function() {
+    const linter = createLinter({
+      "attr-new-line": [
+        true,
+        "+0"
+      ]
+    });
+    const html = `
+      <div 
+          id="bar" attr>
+      </div>
+    `;
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1);
   });
 
   it("Should throw an error when an invalid config is provided", function() {

--- a/lib/rules/attr-new-line/index.js
+++ b/lib/rules/attr-new-line/index.js
@@ -28,31 +28,34 @@ module.exports.lint = function(node, opts, { report }) {
     return;
   }
 
-  const attributes_lines = new Map();
-
-  node.attributes.forEach((attribute) => {
-    const line = attributes_lines.get(attribute.loc.start.line) || [];
-    attributes_lines.set(attribute.loc.start.line, line.concat([attribute]));
+  const attributes_lines = node.attributes.reduce((m, attribute) => {
+    const line = m.get(attribute.loc.start.line) || [];
+    m.set(attribute.loc.start.line, line.concat([attribute]));
     if (attribute.loc.end.line !== attribute.loc.start.line) {
-      const line = attributes_lines.get(attribute.loc.end.line) || [];
-      attributes_lines.set(attribute.loc.end.line, line.concat([attribute]));
+      const line = m.get(attribute.loc.end.line) || [];
+      m.set(attribute.loc.end.line, line.concat([attribute]));
     }
-  });
+    return m;
+  }, new Map());
 
-  const zero_plus = option === "+0";
-  const rowLimit = zero_plus ? 0 : Math.floor(option);
-  // let tag_line = node.loc.start.line;
+  const allow_attributes_on_first_line = option === "+0" || option > 0;
+  const row_limit = (option === 0 || option === "+0")
+    ? 1
+    : Math.floor(option);
+
   const tag_line = node.open.loc.start.line;
+
   const it = attributes_lines.entries();
   let tmp = it.next();
   while (!tmp.done) {
     const [line, attributes] = tmp.value;
-    if (zero_plus && line === tag_line) {
-      attributes.slice(1).map(reportIssue);
+    if (line === tag_line) {
+      const nb_attributes_allowed = allow_attributes_on_first_line
+        ? row_limit
+        : 0;
+      attributes.slice(nb_attributes_allowed).map(reportIssue);
     } else {
-      if (attributes.length > rowLimit) {
-        attributes.slice(rowLimit).map(reportIssue);
-      }
+      attributes.slice(row_limit).map(reportIssue);
     }
     tmp = it.next();
   }


### PR DESCRIPTION
Fix #273.

Now the rule `attr-new-line` will not report errors when there's one attribute per line and the config is `0` and `+0`. This is to match the rule documentation.
