### PR TITLE
Fix self-closed tag spec reference

### DIFF
--- a/lib/rules/tag-close/README.md
+++ b/lib/rules/tag-close/README.md
@@ -42,7 +42,7 @@ Define how void element must be closed.
 
 Possible values :
 
-* `"always"`: Void elements must be self-closed with `/` (html4 style).',
+* `"always"`: Void elements must be self-closed with `/` (xhtml style).',
 * `"never"`: Void elements must not be self-closed with `/` (html5 style).',
 * `false`: No restriction.",
 


### PR DESCRIPTION
Self-closing tags were an XHTML thing to make documents well-formed or sometimes even valid XML.

There’s no need for them according to the HTML 4 spec, see the [typical example](https://www.w3.org/TR/html401/interact/forms.html#h-17.4.2).