### PR TITLE
fix: Correct rule name extract in inline_config "parser"

### DIFF
--- a/packages/linthtml/__tests__/inline_config/fixtures/plugin.js
+++ b/packages/linthtml/__tests__/inline_config/fixtures/plugin.js
@@ -1,0 +1,13 @@
+module.exports = {
+  rules: [
+    {
+      name: "my-plugin/rule",
+      lint(node, format, { report }) {
+        report({
+          code: "something",
+          position: node.loc
+        });
+      }
+    }
+  ]
+};

--- a/packages/linthtml/__tests__/inline_config/fixtures/valid-config-plugin.js
+++ b/packages/linthtml/__tests__/inline_config/fixtures/valid-config-plugin.js
@@ -1,0 +1,8 @@
+const path = require("path");
+
+module.exports = {
+  rules: {
+    "my-plugin/rule": "error"
+  },
+  plugins: [path.join(__dirname, "plugin.js")]
+};

--- a/packages/linthtml/__tests__/inline_config/inline_config.test.ts
+++ b/packages/linthtml/__tests__/inline_config/inline_config.test.ts
@@ -4,6 +4,7 @@ import { expect } from "chai";
 import Config from "../../lib/config";
 import linthtml from "../../lib/index";
 import { LegacyRuleDefinition, RuleDefinition } from "../../lib/read-config";
+import path from "path";
 
 const fooRule: RuleDefinition = {
   name: "foo",
@@ -602,5 +603,24 @@ describe("inline_config with linter", function () {
     `;
     const issues = await linter.lint(html);
     expect(issues).to.have.lengthOf(1);
+  });
+});
+
+describe("inline_config with linter + plugin rule", function () {
+  it("rules from plugin can be configured using inline config", async function () {
+    const config_path = path.join(__dirname, "fixtures", "valid-config-plugin.js");
+    const linter = linthtml.from_config_path(config_path);
+    const html = ["Some text", "<!-- linthtml-configure my-plugin/rule=false -->", "<div></div>"].join("\n");
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1); // One error for the text tag "Some text"
+  });
+  it("rules from plugin can be disabled using inline config", async function () {
+    const config_path = path.join(__dirname, "fixtures", "valid-config-plugin.js");
+    const linter = linthtml.from_config_path(config_path);
+    const html = ["Some text", "<!-- linthtml-disable my-plugin/rule -->", "<div></div>"].join("\n");
+
+    const issues = await linter.lint(html);
+    expect(issues).to.have.lengthOf(1); // One error for the text tag "Some text"
   });
 });


### PR DESCRIPTION
This way rules from plugins can be configured using inline config