### PR TITLE
Fixes references to the rules

### DIFF
--- a/doc/docs/user-guide/rules/list.md
+++ b/doc/docs/user-guide/rules/list.md
@@ -3,63 +3,63 @@
 The following table contains the list of all rules available in Link HTML.
 To learn more about how activate or configure rules, have a look to this [documentation page](../configuration.md).
 
-| Rule name                                                                            | Description                                                                       |
-| :------------------------------------------------------------------------------------| :-------------------------------------------------------------------------        |
-| [attr-bans](./list/attr-bans.md)                                             | Specify a list of disallowed HTML attributes                                      |
-| [attr-name-style](./list/attr-name-style.md)                                 | Enforce naming conventions for HTML tag name                                      |
-| [attr-name-ignore-regex](./list/attr-name-ignore-regex.md)                   |                                                                                   |
-| [attr-new-line](./list/attr-new-line.md)                                     | Specify the numbers of HTML attributes allowed on one line                        |
-| [attr-no-dup](./list/attr-no-dup.md)                                         | Disallow duplications of HTML attributes within the same tag                      |
-| [attr-no-unsafe-char](./list/attr-no-unsafe-char.md)                         | Disallow the use of unsafe unicode char in attributes values                      |
-| [attr-order](./list/attr-order.md)                                           | Specify the order of attributes in an HTML tag.                                   |
-| [attr-quote-style](./list/attr-quote-style.md)                               | Enforce the consistent use of quotes.                                             |
-| [attr-req-value](./list/attr-req-value.md)                                   | Enforce the presence of a value for an HTML attribute                             |
-| [attr-validate](./list/attr-validate.md)                                     | Validate that attributes are correctly written                                    |
-| [button-req-content](./list/button-req-content.md)                           | Enforce the presence of a text content for a button                               |
-| [class-no-dup](./list/class-no-dup.md)                                       | Disallow the presence of the same className within the `class` attribute          |
-| [class-style](./list/class-style.md)                                         | Enforce naming convention for CSS classes                                         |
-| [doctype-first](./list/doctype-first.md)                                     | Enforce the presence of `<!DOCTYPE ...>` on top of an HTML document               |
-| [doctype-html5](./list/doctype-html5.md)                                     | Enforce the use of the HTML5 doctype                                              |
-| [fieldset-contains-legend](./list/fieldset-contains-legend.md)               | Every `fieldset` element should contain a `legend` element                        |
-| [fig-req-figcaption](./list/fig-req-figcaption.md)                           | Enforce the presence of the tag `<figcaption>` inside a `<figure>` tag.           |
-| [focusable-tabindex-style](./list/focusable-tabindex-style.md)               | Disallow the use of positive tabindex (>1)                                        |
-| [head-req-title](./list/head-req-title.md)                                   | Enforce the presence of a `<title>` inside `<head>`                               |
-| [head-valid-content-model](./list/head-valid-content-model.md)               |                                                                                   |
-| [href-style](./list/href-style.md)                                           | `href` must be set with absolute or relative links.                               |
-| [html-req-lang](./list/html-req-lang.md)                                     | Enforce the presence of the `lang` attribute on any `<html>` tag                  |
-| [html-valid-content-model](./list/html-valid-content-model.md)               |                                                                                   |
-| [id-class-ignore-regex](./list/id-class-ignore-regex.md)                     |                                                                                   |
-| [id-class-no-ad](./list/id-class-no-ad.md)                                   |                                                                                   |
-| [id-class-style](./list/id-class-style.md)                                   | Enforce naming convention for HTML ids and CSS classes                            |
-| [id-no-dup](./list/id-no-dup.md)                                             | Disallow duplications of HTML ids within the same document                        |
-| [id-style](./list/id-style.md)                                               | Enforce naming convention for HTML ids                                            |
-| [img-req-alt](./list/img-req-alt.md)                                         | Enforce the presence of a none empty `alt` attribute on `<img>`                   |
-| [img-req-src](./list/img-req-src.md)                                         | Enforce the presence of a none empty `src` attribute on `<img>`                   |
-| [indent-delta](./list/indent-delta.md) _deprecated_                          |                                                                                   |
-| [indent-style](./list/indent-style.md)                                       | Specify indentation style (`tab` or `space`)                                      |
-| [indent-width](./list/indent-width.md)                                       | Specify indentation width                                                         |
-| [indent-width-cont](./list/indent-width-cont.md) _deprecated_                |                                                                                   |
-| [input-btn-req-value-or-title](./list/input-btn-req-value-or-title.md)       | Enforce the presence of a label for `<button>`                                    |
-| [input-radio-req-name](./list/input-radio-req-name.md)                       | Enforce the presence of a none empty `name` attribute on radio input              |
-| [input-req-label](./list/input-req-label.md)                                 | Enforce the presence of a label for `<input>`                                     |
-| [label-no-enc-textarea-or-select](./list/label-no-enc-textarea-or-select.md) | Disallow the presence of `<select>` and `<textarea>` inside a `<label>`           |
-| [label-req-for](./list/label-req-for.md)                                     | Enforce the presence of a none empty `name` attribute on `<label>`                |
-| [lang-style](./list/lang-style.md)                                           |                                                                                   |
-| [line-end-style](./list/line-end-style.md)                                   |                                                                                   |
-| [line-max-len](./list/line-max-len.md)                                       | Limit the length of a line                                                        |
-| [line-max-len-ignore-regex](./list/line-max-len-ignore-regex.md)             |                                                                                   |
-| [line-no-trailing-whitespace](./list/line-no-trailing-whitespace.md)         | Disallow trailing whitespace at the end of lines                                  |
-| [link-min-length-4](./list/link-min-length-4.md)                             | Disallow link text with less than 4 chars                                         |
-| [link-req-noopener](./list/link-req-noopener.md)                             | Enforce the presence of `rel="noopener"` or `rel="noreferrer"` attribute on `<a>` |
-| [spec-char-escape](./list/spec-char-escape.md)                               |                                                                                   |
-| [table-req-caption](./list/table-req-caption.md)                             | Enforce the presence of `<caption>` inside `<table>`                              |
-| [table-req-header](./list/table-req-header.md)                               | Enforce the presence of `<thead>` inside `<table>`                                |
-| [tag-bans](./list/tag-bans.md)                                               | Define a list of HTML tags that are forbidden                                     |
-| [tag-close](./list/tag-close.md)                                             |                                                                                   |
-| [tag-name-lowercase](./list/tag-name-lowercase.md)                           | Enforce the use of lowercase for tag name                                         |
-| [tag-name-match](./list/tag-name-match.md)                                   |                                                                                   |
-| [tag-req-attr](./list/tag-req-attr.md)                                       | Define a list of attributes that must be present on an HTML tag                   |
-| [tag-self-close](./list/tag-self-close.md)                                   | Define whether or not a self-close tag should end with `/>`                       |
-| [text-ignore-regex](./list/text-ignore-regex.md)                             |                                                                                   |
-| [title-max-len](./list/title-max-len.md)                                     | Fix a maximum lenght an the `<title>` content                                     |
-| [title-no-dup](./list/title-no-dup.md)                                       | Disallow the presence of multiple `<title>`                                       |
+| Rule name                                                                                                     | Description                                                                       |
+|:--------------------------------------------------------------------------------------------------------------| :-------------------------------------------------------------------------        |
+| [attr-bans](../../../../packages/linthtml/lib/rules/attr-bans/README.md)                                      | Specify a list of disallowed HTML attributes                                      |
+| [attr-name-style](../../../../packages/linthtml/lib/rules/attr-name-style/README.md)                                 | Enforce naming conventions for HTML tag name                                      |
+| [attr-name-ignore-regex](../../../../packages/linthtml/lib/rules/attr-name-ignore-regex/README.md)                   |                                                                                   |
+| [attr-new-line](../../../../packages/linthtml/lib/rules/attr-new-line/README.md)                                     | Specify the numbers of HTML attributes allowed on one line                        |
+| [attr-no-dup](../../../../packages/linthtml/lib/rules/attr-no-dup/README.md)                                         | Disallow duplications of HTML attributes within the same tag                      |
+| [attr-no-unsafe-char](../../../../packages/linthtml/lib/rules/attr-no-unsafe-char/README.md)                         | Disallow the use of unsafe unicode char in attributes values                      |
+| [attr-order](../../../../packages/linthtml/lib/rules/attr-order/README.md)                                           | Specify the order of attributes in an HTML tag.                                   |
+| [attr-quote-style](../../../../packages/linthtml/lib/rules/attr-quote-style/README.md)                               | Enforce the consistent use of quotes.                                             |
+| [attr-req-value](../../../../packages/linthtml/lib/rules/attr-req-value/README.md)                                   | Enforce the presence of a value for an HTML attribute                             |
+| [attr-validate](../../../../packages/linthtml/lib/rules/attr-validate/README.md)                                     | Validate that attributes are correctly written                                    |
+| [button-req-content](../../../../packages/linthtml/lib/rules/button-req-content/README.md)                           | Enforce the presence of a text content for a button                               |
+| [class-no-dup](../../../../packages/linthtml/lib/rules/class-no-dup/README.md)                                       | Disallow the presence of the same className within the `class` attribute          |
+| [class-style](../../../../packages/linthtml/lib/rules/class-style/README.md)                                         | Enforce naming convention for CSS classes                                         |
+| [doctype-first](../../../../packages/linthtml/lib/rules/doctype-first/README.md)                                     | Enforce the presence of `<!DOCTYPE ...>` on top of an HTML document               |
+| [doctype-html5](../../../../packages/linthtml/lib/rules/doctype-html5/README.md)                                     | Enforce the use of the HTML5 doctype                                              |
+| [fieldset-contains-legend](../../../../packages/linthtml/lib/rules/fieldset-contains-legend/README.md)               | Every `fieldset` element should contain a `legend` element                        |
+| [fig-req-figcaption](../../../../packages/linthtml/lib/rules/fig-req-figcaption/README.md)                           | Enforce the presence of the tag `<figcaption>` inside a `<figure>` tag.           |
+| [focusable-tabindex-style](../../../../packages/linthtml/lib/rules/focusable-tabindex-style/README.md)               | Disallow the use of positive tabindex (>1)                                        |
+| [head-req-title](../../../../packages/linthtml/lib/rules/head-req-title/README.md)                                   | Enforce the presence of a `<title>` inside `<head>`                               |
+| [head-valid-content-model](../../../../packages/linthtml/lib/rules/head-valid-content-model/README.md)               |                                                                                   |
+| [href-style](../../../../packages/linthtml/lib/rules/href-style/README.md)                                           | `href` must be set with absolute or relative links.                               |
+| [html-req-lang](../../../../packages/linthtml/lib/rules/html-req-lang/README.md)                                     | Enforce the presence of the `lang` attribute on any `<html>` tag                  |
+| [html-valid-content-model](../../../../packages/linthtml/lib/rules/html-valid-content-model/README.md)               |                                                                                   |
+| [id-class-ignore-regex](../../../../packages/linthtml/lib/rules/id-class-ignore-regex/README.md)                     |                                                                                   |
+| [id-class-no-ad](../../../../packages/linthtml/lib/rules/id-class-no-ad/README.md)                                   |                                                                                   |
+| [id-class-style](../../../../packages/linthtml/lib/rules/id-class-style/README.md)                                   | Enforce naming convention for HTML ids and CSS classes                            |
+| [id-no-dup](../../../../packages/linthtml/lib/rules/id-no-dup/README.md)                                             | Disallow duplications of HTML ids within the same document                        |
+| [id-style](../../../../packages/linthtml/lib/rules/id-style/README.md)                                               | Enforce naming convention for HTML ids                                            |
+| [img-req-alt](../../../../packages/linthtml/lib/rules/img-req-alt/README.md)                                         | Enforce the presence of a none empty `alt` attribute on `<img>`                   |
+| [img-req-src](../../../../packages/linthtml/lib/rules/img-req-src./READMEmd)                                         | Enforce the presence of a none empty `src` attribute on `<img>`                   |
+| [indent-delta](../../../../packages/linthtml/lib/rules/indent-delta/README.md) _deprecated_                          |                                                                                   |
+| [indent-style](../../../../packages/linthtml/lib/rules/indent-style/README.md)                                       | Specify indentation style (`tab` or `space`)                                      |
+| [indent-width](../../../../packages/linthtml/lib/rules/indent-width/README.md)                                       | Specify indentation width                                                         |
+| [indent-width-cont](../../../../packages/linthtml/lib/rules/indent-width-cont/README.md) _deprecated_                |                                                                                   |
+| [input-btn-req-value-or-title](../../../../packages/linthtml/lib/rules/input-btn-req-value-or-title/README.md)       | Enforce the presence of a label for `<button>`                                    |
+| [input-radio-req-name](../../../../packages/linthtml/lib/rules/input-radio-req-name/README.md)                       | Enforce the presence of a none empty `name` attribute on radio input              |
+| [input-req-label](../../../../packages/linthtml/lib/rules/input-req-label/README.md)                                 | Enforce the presence of a label for `<input>`                                     |
+| [label-no-enc-textarea-or-select](../../../../packages/linthtml/lib/rules/label-no-enc-textarea-or-select/README.md) | Disallow the presence of `<select>` and `<textarea>` inside a `<label>`           |
+| [label-req-for](../../../../packages/linthtml/lib/rules/label-req-for/README.md)                                     | Enforce the presence of a none empty `name` attribute on `<label>`                |
+| [lang-style](../../../../packages/linthtml/lib/rules/lang-style/README.md)                                           |                                                                                   |
+| [line-end-style](../../../../packages/linthtml/lib/rules/line-end-style/README.md)                                   |                                                                                   |
+| [line-max-len](../../../../packages/linthtml/lib/rules/line-max-len/README.md)                                       | Limit the length of a line                                                        |
+| [line-max-len-ignore-regex](../../../../packages/linthtml/lib/rules/line-max-len-ignore-regex/README.md)             |                                                                                   |
+| [line-no-trailing-whitespace](../../../../packages/linthtml/lib/rules/line-no-trailing-whitespace/README.md)         | Disallow trailing whitespace at the end of lines                                  |
+| [link-min-length-4](../../../../packages/linthtml/lib/rules/link-min-length-4/README.md)                             | Disallow link text with less than 4 chars                                         |
+| [link-req-noopener](../../../../packages/linthtml/lib/rules/link-req-noopener/README.md)                             | Enforce the presence of `rel="noopener"` or `rel="noreferrer"` attribute on `<a>` |
+| [spec-char-escape](../../../../packages/linthtml/lib/rules/spec-char-escape/README.md)                               |                                                                                   |
+| [table-req-caption](../../../../packages/linthtml/lib/rules/table-req-caption/README.md)                             | Enforce the presence of `<caption>` inside `<table>`                              |
+| [table-req-header](../../../../packages/linthtml/lib/rules/table-req-header/README.md)                               | Enforce the presence of `<thead>` inside `<table>`                                |
+| [tag-bans](../../../../packages/linthtml/lib/rules/tag-bans/README.md)                                        | Define a list of HTML tags that are forbidden                                     |
+| [tag-close](../../../../packages/linthtml/lib/rules/tag-close/README.md)                                      |                                                                                   |
+| [tag-name-lowercase](../../../../packages/linthtml/lib/rules/tag-name-lowercase/README.md)                    | Enforce the use of lowercase for tag name                                         |
+| [tag-name-match](../../../../packages/linthtml/lib/rules/tag-name-match/README.md)                            |                                                                                   |
+| [tag-req-attr](../../../../packages/linthtml/lib/rules/tag-req-attr/README.md)                                | Define a list of attributes that must be present on an HTML tag                   |
+| [tag-self-close](../../../../packages/linthtml/lib/rules/tag-self-close/README.md)                            | Define whether or not a self-close tag should end with `/>`                       |
+| [text-ignore-regex](../../../../packages/linthtml/lib/rules/text-ignore-regex/README.md)                      |                                                                                   |
+| [title-max-len](../../../../packages/linthtml/lib/rules/title-max-len/README.md)                              | Fix a maximum lenght an the `<title>` content                                     |
+| [title-no-dup](../../../../packages/linthtml/lib/rules/title-no-dup/README.md)                                | Disallow the presence of multiple `<title>`                                       |


### PR DESCRIPTION
On the link https://github.com/linthtml/linthtml/blob/develop/doc/docs/user-guide/rules/list.md, which is presented in the main README.md, the links to the rules do not work.

[The functionality can be checked in the fork](https://github.com/nikolai-shabalin/linthtml/blob/develop/doc/docs/user-guide/rules/list.md)