### PR TITLE
chore: Improve TS types for dom elements

### DIFF
--- a/packages/core/src/rules/attr-validate/index.ts
+++ b/packages/core/src/rules/attr-validate/index.ts
@@ -1,10 +1,10 @@
 import { is_tag_node } from "@linthtml/dom-utils";
-import type { Node } from "@linthtml/dom-utils/dom_elements";
+import type { Element, Node } from "@linthtml/dom-utils/dom_elements";
 import type { reportFunction, RuleDefinition } from "../../read-config.js";
 
 const RULE_NAME = "attr-validate";
 
-function get_open_raw({ open }: Node) {
+function get_open_raw({ open }: Element) {
   const open_raw = open.raw as string;
   return open_raw
     .replace(/^</, "")

--- a/packages/core/src/rules/doctype-first/index.ts
+++ b/packages/core/src/rules/doctype-first/index.ts
@@ -23,12 +23,10 @@ function is_whitespace(node: Node) {
 function lint(node: Node, mode: string, { report }: { report: reportFunction }) {
   // CHECK if parent if first child instead
   // @ts-expect-error USE parents and sibling instead
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   if (this.passedFirst || is_comment_node(node) || is_whitespace(node)) {
     return;
   }
   // @ts-expect-error USE parents and sibling instead
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   this.passedFirst = true;
 
   if (is_directive_node(node) && node.name.toUpperCase() === "!DOCTYPE") {
@@ -42,7 +40,7 @@ function lint(node: Node, mode: string, { report }: { report: reportFunction }) 
 
   report({
     code: "E007",
-    position: node.open ? node.open.loc : node.loc
+    position: is_tag_node(node) ? node.open.loc : node.loc
   });
 }
 

--- a/packages/core/src/rules/head-valid-content-model/index.ts
+++ b/packages/core/src/rules/head-valid-content-model/index.ts
@@ -1,6 +1,6 @@
 import { is_tag_node } from "@linthtml/dom-utils";
 import type { reportFunction, RuleDefinition } from "../../read-config.js";
-import type { Node } from "@linthtml/dom-utils/dom_elements";
+import type { Element, Node } from "@linthtml/dom-utils/dom_elements";
 
 const RULE_NAME = "head-valid-content-model";
 
@@ -9,7 +9,7 @@ const legal_children = ["base", "link", "meta", "noscript", "script", "style", "
 function lint(node: Node, _config: unknown, { report }: { report: reportFunction }) {
   if (is_tag_node(node) && node.name === "head") {
     node.children
-      .filter((child) => is_tag_node(child) && legal_children.indexOf(child.name) < 0)
+      .filter((child): child is Element => is_tag_node(child) && legal_children.indexOf(child.name) < 0)
       .forEach((child) =>
         report({
           code: "E047",

--- a/packages/core/src/rules/indent-style/index.ts
+++ b/packages/core/src/rules/indent-style/index.ts
@@ -1,5 +1,5 @@
 import { is_text_node, node_tag_name, has_parent_node, is_newline_only } from "@linthtml/dom-utils";
-import type { CharValue, Node, Text } from "@linthtml/dom-utils/dom_elements";
+import type { CharValue, Element, Node, Text } from "@linthtml/dom-utils/dom_elements";
 import type { reportFunction, RuleDefinition } from "../../read-config.js";
 import { create_list_value_validator } from "../../validate_option.js";
 
@@ -28,8 +28,8 @@ function is_sibling_close_tag_same_line(node: Node) {
 function is_parent_open_close_same_line(node: Node) {
   return (
     has_parent_node(node) &&
-    (node.parent as Node).open.loc.end.line === node.loc.start.line &&
-    (node.parent as Node).loc.end.line === node.loc.end.line
+    (node.parent as Element).open.loc.end.line === node.loc.start.line &&
+    (node.parent as Element).loc.end.line === node.loc.end.line
   );
 }
 
@@ -40,7 +40,7 @@ function is_parent_open_close_same_line(node: Node) {
  * If alone on line and indent width not correct => report
  * If alone on line and indent width  correct => do not report
  */
-function check_indent_width(node: Node, expectedIndentWidth: number) {
+function check_indent_width(node: Element, expectedIndentWidth: number) {
   if (is_parent_open_close_same_line(node)) {
     return true;
   }
@@ -50,7 +50,7 @@ function check_indent_width(node: Node, expectedIndentWidth: number) {
   return node.loc.start.column - 1 === expectedIndentWidth;
 }
 
-function check_indent_width_close({ open, close }: Node) {
+function check_indent_width_close({ open, close }: Element) {
   if (close === undefined) {
     return true;
   }
@@ -99,7 +99,7 @@ function indent_style_used(node: Node) {
 }
 
 function check_node_indent(
-  node: Node,
+  node: Element,
   indent: { width: false | number; style: "spaces" | "tabs" | "mixed" },
   expected_indent_width: number,
   report: reportFunction
@@ -176,7 +176,7 @@ function lint(
   const style = (global_config["indent-style"] as false | "spaces" | "tabs" | "mixed") || "spaces"; // TODO: Get rid of false
   const width = (global_config["indent-width"] as false | number) || false; // TODO: Add default value?
 
-  check_node_indent(node, { style, width }, (width as number) * level, report);
+  check_node_indent(node as Element, { style, width }, (width as number) * level, report);
 }
 
 export default {

--- a/packages/core/src/rules/title-no-dup/index.ts
+++ b/packages/core/src/rules/title-no-dup/index.ts
@@ -1,12 +1,12 @@
 import { is_tag_node } from "@linthtml/dom-utils";
-import type { Node } from "@linthtml/dom-utils/dom_elements";
+import type { Element, Node } from "@linthtml/dom-utils/dom_elements";
 import type { reportFunction, RuleDefinition } from "../../read-config.js";
 
 const RULE_NAME = "title-no-dup";
 
 function lint(node: Node, _config: unknown, { report }: { report: reportFunction }) {
   if (is_tag_node(node) && node.name === "head") {
-    const titles = node.children.filter((child) => is_tag_node(child) && child.name === "title");
+    const titles = node.children.filter((child): child is Element => is_tag_node(child) && child.name === "title");
 
     if (titles.length > 1) {
       titles.slice(1).forEach((title) =>

--- a/packages/dom-utils/src/dom_elements.ts
+++ b/packages/dom-utils/src/dom_elements.ts
@@ -64,26 +64,6 @@ export class Position {
   }
 }
 
-interface SourceCodeLocation {
-  /** One-based line index of the first character. */
-  startLine: number;
-  /** One-based column index of the first character. */
-  startCol: number;
-  /** Zero-based first character index. */
-  startOffset: number;
-  /** One-based line index of the last character. */
-  endLine: number;
-  /** One-based column index of the last character. Points directly *after* the last character. */
-  endCol: number;
-  /** Zero-based last character index. Points directly *after* the last character. */
-  endOffset: number;
-}
-
-interface TagSourceCodeLocation extends SourceCodeLocation {
-  startTag?: SourceCodeLocation;
-  endTag?: SourceCodeLocation;
-}
-
 /**
  * A node that can have children.
  */
@@ -127,13 +107,6 @@ export abstract class Node {
 
   /** The end index of the node. Requires `withEndIndices` on the handler to be `true. */
   endIndex: number | null = null;
-
-  /**
-   * `parse5` source code location info.
-   *
-   * Available if parsing with parse5 and location info is enabled.
-   */
-  sourceCodeLocation?: SourceCodeLocation | null;
 
   // Read-only aliases
 
@@ -203,32 +176,6 @@ export abstract class Node {
 
   set loc(value) {
     this._loc = value;
-  }
-
-  // @ts-expect-error Ignore
-  private _open: CharValue;
-  /**
-   * Node open tag details
-   */
-  get open() {
-    return this._open;
-  }
-
-  set open(value) {
-    this._open = value;
-  }
-
-  private _close: CharValue | undefined = undefined;
-  /**
-   * Node close tag details.
-   * _Can be null for self closing tag_
-   */
-  get close() {
-    return this._close;
-  }
-
-  set close(value) {
-    this._close = value;
   }
 }
 
@@ -336,6 +283,32 @@ export abstract class NodeWithChildren extends Node {
   set childNodes(children: ChildNode[]) {
     this.children = children;
   }
+
+  // @ts-expect-error Ignore
+  private _open: CharValue;
+  /**
+   * Node open tag details
+   */
+  get open() {
+    return this._open;
+  }
+
+  set open(value) {
+    this._open = value;
+  }
+
+  private _close: CharValue | undefined = undefined;
+  /**
+   * Node close tag details.
+   * _Can be null for self closing tag_
+   */
+  get close() {
+    return this._close;
+  }
+
+  set close(value) {
+    this._close = value;
+  }
 }
 
 /**
@@ -388,13 +361,6 @@ export class Element extends NodeWithChildren {
   get nodeType(): 1 {
     return 1;
   }
-
-  /**
-   * `parse5` source code location info, with start & end tags.
-   *
-   * Available if parsing with parse5 and location info is enabled.
-   */
-  sourceCodeLocation?: TagSourceCodeLocation | null;
 
   // DOM Level 1 aliases
 

--- a/packages/html-parser/src/__tests__/parser.test.ts
+++ b/packages/html-parser/src/__tests__/parser.test.ts
@@ -1,12 +1,14 @@
 import { describe, it } from "mocha";
 import { expect } from "chai";
-import type { Element } from "@linthtml/dom-utils/dom_elements";
 import parse from "../index.js";
+import type { Element } from "@linthtml/dom-utils";
 
 describe("HTML Parser", function () {
   it("Tags positions are correct (nesting)", function () {
     const { children } = parse(["<body>", '  <div a="jofwei">', "    TextTextText", "  </div>", "</body>"].join("\n"));
-    expect(children[0].open.loc).to.deep.equal({
+    const body = children[0] as Element;
+
+    expect(body.open.loc).to.deep.equal({
       start: {
         line: 1,
         column: 1
@@ -16,7 +18,7 @@ describe("HTML Parser", function () {
         column: 7
       }
     });
-    expect(children[0]?.close?.loc).to.deep.equal({
+    expect(body.close?.loc).to.deep.equal({
       start: {
         line: 5,
         column: 1
@@ -26,7 +28,8 @@ describe("HTML Parser", function () {
         column: 8
       }
     });
-    expect(children[0].children[1].open.loc).to.deep.equal({
+    const div = body.children[1] as Element;
+    expect(div.open.loc).to.deep.equal({
       start: {
         line: 2,
         column: 3
@@ -36,7 +39,7 @@ describe("HTML Parser", function () {
         column: 19
       }
     });
-    expect(children[0]?.children[1]?.close?.loc).to.deep.equal({
+    expect(div.close?.loc).to.deep.equal({
       start: {
         line: 4,
         column: 3
@@ -128,7 +131,7 @@ describe("HTML Parser", function () {
     const { children } = parse(
       ["<body>", '  <div class="hello" id="identityDiv" class="goodbye">', "  </div>", "</body>"].join("\n")
     );
-    const div = <Element>children[0].children[1];
+    const div = children[0].children[1] as Element;
 
     expect(div.attributes).to.have.lengthOf(3);
     const [class_1, id, class_2] = div.attributes;
@@ -282,7 +285,7 @@ describe("HTML Parser", function () {
     const { children } = parse(
       ["<body>", "  <div", '    class="hello"', '    id="identityDiv"', "  >", "  </div>", "</body>"].join("\n")
     );
-    const div = <Element>children[0].children[1];
+    const div = children[0].children[1] as Element;
 
     expect(div.attributes).to.have.lengthOf(2);
     const [_class, id] = div.attributes;
@@ -368,7 +371,7 @@ describe("HTML Parser", function () {
     const { children } = parse(
       ["<body>", "  <div", '    class="hello', '      identityDiv"', "  >", "  </div>", "</body>"].join("\n")
     );
-    const div = <Element>children[0].children[1];
+    const div = children[0].children[1] as Element;
 
     expect(div.attributes).to.have.lengthOf(1);
     const [_class] = div.attributes;


### PR DESCRIPTION
Correcting the TS types to only allow open/close properties for tag with children