### PR TITLE
Improve lang-style rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9067,6 +9067,13 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/@types/language-tags": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/language-tags/-/language-tags-1.0.4.tgz",
+      "integrity": "sha512-20PQbifv3v/djCT+KlXybv0KqO5ofoR1qD1wkinN59kfggTPVTWGmPFgL/1yWuDyRcsQP/POvkqK+fnl5nOwTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/lodash": {
       "version": "4.14.202",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
@@ -20418,6 +20425,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/latest-version": {
       "version": "7.0.0",
@@ -33163,11 +33176,13 @@
         "global-modules": "^2.0.0",
         "globby": "^13.0.0",
         "ignore": "^5.3.1",
+        "language-tags": "^1.0.0",
         "lodash.pull": "4.1.0",
         "resolve-from": "^5.0.0"
       },
       "devDependencies": {
         "@types/global-modules": "^2.0.0",
+        "@types/language-tags": "^1.0.4",
         "@types/lodash.pull": "^4.1.6",
         "@types/resolve-from": "^5.0.1",
         "rewiremock": "^3.14.3"
@@ -33214,6 +33229,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/core/node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "packages/core/node_modules/slash": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,11 +60,13 @@
     "global-modules": "^2.0.0",
     "globby": "^13.0.0",
     "ignore": "^5.3.1",
+    "language-tags": "^1.0.9",
     "lodash.pull": "4.1.0",
     "resolve-from": "^5.0.0"
   },
   "devDependencies": {
     "@types/global-modules": "^2.0.0",
+    "@types/language-tags": "^1.0.4",
     "@types/lodash.pull": "^4.1.6",
     "@types/resolve-from": "^5.0.1",
     "rewiremock": "^3.14.3"

--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -91,7 +91,14 @@ export const ISSUE_ERRORS = {
     return `Incorrect indentation for \`${data.tagName}\` beginning at L${start.line}:C${start.column}. Expected \`${tag}\` to be at an indentation of ${data.expected_indentation} but was found at ${data.current_indentation}.`;
   },
   E037: (data: { limit: string }) => `Only ${data.limit} attributes per line are permitted`,
-  E038: (data: { lang: string }) => `Value "${data.lang}" for attribute "lang" is not valid`,
+  E038: (
+    data:
+      | { lang: string; isDeprecated: false; preferred?: string }
+      | { lang: string; isDeprecated: true; preferred: string }
+  ) =>
+    data.isDeprecated
+      ? `Value "${data.lang}" for attribute "lang" is deprecated, use "${data.preferred}" instead.`
+      : `Value "${data.lang}" for attribute "lang" is not valid`,
   E039: (data: { lang: string }) => `Value "${data.lang}" for attribute "lang" is not properly capitalized`,
   E040: (data: { length: number; maxlength: number }) =>
     `This line has a length of ${data.length}. Maximum allowed is ${data.maxlength}`,

--- a/packages/core/src/rules/lang-style/README.md
+++ b/packages/core/src/rules/lang-style/README.md
@@ -4,8 +4,12 @@ If set, the lang tag must have a valid form (`xx-YY`, where `xx` is a valid lang
 
 Given:
 
-```
-  "lang-style": [true, "xx"]
+```json
+{
+  "rules": {
+    "lang-style": "error"
+  }
+}
 ```
 
 The following patterns are considered violations:

--- a/packages/core/src/rules/lang-style/index.test.ts
+++ b/packages/core/src/rules/lang-style/index.test.ts
@@ -139,6 +139,7 @@ describe("lang-style", function () {
 
     const issues = await linter.lint(html);
     expect(issues).to.have.lengthOf(1);
+    expect(issues[0].code).to.equal("E039");
   });
 
   it("Should not report any for correct case lang", async function () {

--- a/packages/core/src/rules/lang-style/index.ts
+++ b/packages/core/src/rules/lang-style/index.ts
@@ -1,6 +1,7 @@
 import type { reportFunction, RuleDefinition } from "../../read-config.js";
-import { check_lang_attribute, is_tag_node, attribute_value, has_non_empty_attribute } from "@linthtml/dom-utils";
+import { is_tag_node, attribute_value, has_non_empty_attribute } from "@linthtml/dom-utils";
 import type { CharValue, Node } from "@linthtml/dom-utils/dom_elements";
+import tags from "language-tags";
 
 const RULE_NAME = "lang-style";
 
@@ -25,19 +26,24 @@ function lint(node: Node, lang_case: string, { report }: { report: reportFunctio
       return;
     }
 
-    const valid = check_lang_attribute(lang); // WHAT???
-    if (valid === 1) {
+    const tag = tags(lang.chars);
+
+    if (!tag.valid()) {
+      const isDeprecated = tag.deprecated() !== undefined;
       report({
         code: "E038",
         position: lang.loc,
         meta: {
           data: {
-            lang: lang.chars
+            lang: lang.chars,
+            isDeprecated,
+            preferred: isDeprecated && tag.preferred().format()
           }
         }
       });
     }
-    if (lang_case === "case" && valid === 2) {
+
+    if (lang_case === "case" && tag.format() !== lang.chars) {
       report({
         code: "E039",
         position: lang.loc,


### PR DESCRIPTION
The rule now relies on the (language-tags)[https://www.npmjs.com/package/language-tags] package to validate the lang attribute value. The rule error message will now also report deprecated value and hint alternatives